### PR TITLE
Include linux/quota.h when not using glibc

### DIFF
--- a/src/partitionmanager.cpp
+++ b/src/partitionmanager.cpp
@@ -44,6 +44,9 @@
 #include <mntent.h>
 #include <sys/statvfs.h>
 #include <sys/quota.h>
+#if !defined(__GLIBC__)
+#include <linux/quota.h>
+#endif
 #include <unistd.h>
 
 static const auto userName = QString(qgetenv("USER"));


### PR DESCRIPTION
Otherwise if_dqblk is considered an incomplete type, at least on Musl

This is a recreation of https://git.sailfishos.org/mer-core/nemo-qml-plugin-systemsettings/merge_requests/174 as sadly you guys are moving away from the FOSS Gitlab. Please check there for existing comments.