### PR TITLE
[systemsettings] skip disks from partitions starting with /dev/sailfish/

### DIFF
--- a/src/udisks2block.cpp
+++ b/src/udisks2block.cpp
@@ -261,7 +261,7 @@ bool UDisks2::Block::isReadOnly() const
 bool UDisks2::Block::isExternal() const
 {
     const QString prefDevice = preferredDevice();
-    return prefDevice != QStringLiteral("/dev/sailfish/home") && prefDevice != QStringLiteral("/dev/sailfish/root")
+    return !prefDevice.startsWith(QStringLiteral("/dev/sailfish/"))
             && mountPath() != QStringLiteral("/home") && mountPath() != QStringLiteral("/");
 }
 


### PR DESCRIPTION
This PR skips all partitions that start with `/dev/sailfish/` and avoids listing them as SD cards. For Tama, I had to move `/dev/sailfish/home` to other LV name to avoid interference between device security code and LUKS keyslot password.