### PR TITLE
[nemo-qml-plugin-systemsettings] Move location config to /var. Contributes to JB#56083

### DIFF
--- a/rpm/nemo-qml-plugin-systemsettings.spec
+++ b/rpm/nemo-qml-plugin-systemsettings.spec
@@ -3,7 +3,7 @@ Summary:    System settings plugin for Nemo Mobile
 Version:    0.5.75
 Release:    1
 License:    BSD
-URL:        https://git.sailfishos.org/mer-core/nemo-qml-plugin-systemsettings
+URL:        https://github.com/sailfishos/nemo-qml-plugin-systemsettings/
 Source0:    %{name}-%{version}.tar.bz2
 Requires(post): /sbin/ldconfig
 Requires(postun): /sbin/ldconfig
@@ -100,6 +100,8 @@ fi
 %attr(4710,-,privileged) %{_libexecdir}/setlocale
 %dir %attr(0775, root, privileged) /etc/location
 %config %attr(0664, root, privileged) /etc/location/location.conf
+%dir %attr(0775, root, privileged) /var/lib/location
+%config %attr(0664, root, privileged) /var/lib/location/location.conf
 %{_datadir}/translations/*.qm
 
 %files devel

--- a/src/locationsettings_p.h
+++ b/src/locationsettings_p.h
@@ -89,7 +89,7 @@ private slots:
 class IniFile
 {
 public:
-    IniFile(const QString &fileName);
+    IniFile(const QString &fileName, const QString &compatibilityFileName = QString());
     ~IniFile();
 
     bool isValid() const;
@@ -100,6 +100,7 @@ public:
 private:
     mutable QScopedPointer<Sailfish::KeyProvider::ProcessMutex> m_processMutex;
     QString m_fileName;
+    QString m_compatibilityFileName;
     GKeyFile *m_keyFile;
     GError *m_error;
     bool m_modified;

--- a/src/src.pro
+++ b/src/src.pro
@@ -96,7 +96,10 @@ pkgconfig.files = $$PWD/pkgconfig/systemsettings.pc
 pkgconfig.path = $$target.path/pkgconfig
 
 locationconfig.files = $$PWD/location.conf
-locationconfig.path = /etc/location
+locationconfig.path = /var/lib/location
+
+compat_locationconfig.files = $$PWD/location.conf
+compat_locationconfig.path = /etc/location
 
 QMAKE_PKGCONFIG_NAME = lib$$TARGET
 QMAKE_PKGCONFIG_VERSION = $$VERSION
@@ -106,4 +109,4 @@ QMAKE_PKGCONFIG_INCDIR = $$develheaders.path
 QMAKE_PKGCONFIG_DESTDIR = pkgconfig
 QMAKE_PKGCONFIG_REQUIRES = Qt5Core Qt5DBus profile libsailfishkeyprovider connman-qt5
 
-INSTALLS += target develheaders pkgconfig locationconfig
+INSTALLS += target develheaders pkgconfig locationconfig compat_locationconfig


### PR DESCRIPTION
Sandboxing doesn't like to have files modified under /etc as private-etc
will copy the content on startup and later changes are not applied.

Moved the config under /var/lib/location/ instead, but the old path
is also getting written to keep compatibility with code that reads the
file directly, not via LocationSettings class.

This will reset the settings state. Would be nice to copy the old file,
but that should be done only once and this is also now packaging
the initial states so it's tricky.

@Tomin1 @spiiroin 