### PR TITLE
[nemo-qml-plugin-systemsettings] Cleanup unimplemented Finished slots from user model. Fixes JB#55291 OMP#JOLLA-506

### DIFF
--- a/src/usermodel.h
+++ b/src/usermodel.h
@@ -144,14 +144,6 @@ private slots:
     void onCurrentUserChangeFailed(uint uid);
     void onGuestUserEnabled(bool enabled);
 
-    void userAddFinished(QDBusPendingCallWatcher *call);
-    void userModifyFinished(QDBusPendingCallWatcher *call, uint uid);
-    void userRemoveFinished(QDBusPendingCallWatcher *call, uint uid);
-    void setCurrentUserFinished(QDBusPendingCallWatcher *call, uint uid);
-    void addToGroupsFinished(QDBusPendingCallWatcher *call, uint uid);
-    void removeFromGroupsFinished(QDBusPendingCallWatcher *call, uint uid);
-    void enableGuestUserFinished(QDBusPendingCallWatcher *call, bool enabling);
-
     void createInterface();
     void destroyInterface();
 


### PR DESCRIPTION
With sha1 be2f6f9ba5c4f206dd9314d8eafddf67e3b8fd onError and onFinished
D-Bus replies are handled as lambdas.