### PR TITLE
[nemo-qml-plugin-systemsettings] Get application permissions from sailjail. Fixes JB#56188 OMP#JOLLA-527

### DIFF
--- a/src/permissionsmodel.h
+++ b/src/permissionsmodel.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Open Mobile Platform LLC.
+ * Copyright (c) 2020 - 2021 Open Mobile Platform LLC.
  *
  * You may use this file under the terms of the BSD license as follows:
  *
@@ -65,6 +65,7 @@ signals:
     void countChanged();
 
 private:
+    void clearPermissions();
     void loadPermissions();
 
     QString m_desktopFile;


### PR DESCRIPTION
Reading application sandboxing permissions from desktop file does not take
into account things like default profile sandboxing.

Query application permissions from sailjail daemon.

Signed-off-by: Simo Piiroinen <simo.piiroinen@jolla.com>