### PR TITLE
[nemo-qml-plugin-systemsettings] Remove storage info api from AboutSettings. JB#56808

### DIFF
--- a/src/aboutsettings.h
+++ b/src/aboutsettings.h
@@ -61,21 +61,6 @@ public:
     explicit AboutSettings(QObject *parent = 0);
     virtual ~AboutSettings();
 
-    // Deprecated -- use diskUsageModel() instead
-    Q_INVOKABLE qlonglong totalDiskSpace() const;
-    // Deprecated -- use diskUsageModel() instead
-    Q_INVOKABLE qlonglong availableDiskSpace() const;
-
-    /**
-     * Returns a list of JS objects with the following keys:
-     *  - storageType: one of "mass" (mass storage), "system" (system storage) or "user" (user storage)
-     *  - path: filesystem path (e.g. "/" or "/home/")
-     *  - available: available bytes on the storage
-     *  - total: total bytes on the storage
-     **/
-    Q_INVOKABLE QVariant diskUsageModel() const;
-    Q_INVOKABLE void refreshStorageModels();
-
     QString wlanMacAddress() const;
     QString imei() const;
     QString serial() const;
@@ -90,13 +75,7 @@ public:
     QString vendorName() const;
     QString vendorVersion() const;
 
-signals:
-    void storageChanged();
-
 private:
-    void partitionCountChanged();
-    void reloadStorageLists();
-
     Q_DECLARE_PRIVATE(AboutSettings)
     Q_DISABLE_COPY(AboutSettings)
 

--- a/src/aboutsettings_p.h
+++ b/src/aboutsettings_p.h
@@ -37,8 +37,6 @@
 #include <QDeviceInfo>
 #include <QVariantList>
 
-#include "partitionmanager.h"
-
 class AboutSettingsPrivate : public QObject
 {
     Q_OBJECT
@@ -49,10 +47,6 @@ public:
 
     QNetworkInfo networkInfo;
     QDeviceInfo deviceInfo;
-
-    QVariantList internalStorage;
-
-    PartitionManager partitionManager;
 
     mutable QMap<QString, QString> osRelease;
     mutable QMap<QString, QString> osReleaseLocalization;

--- a/src/plugin/plugins.qmltypes
+++ b/src/plugin/plugins.qmltypes
@@ -25,11 +25,6 @@ Module {
         Property { name: "adaptationVersion"; type: "string"; isReadonly: true }
         Property { name: "vendorName"; type: "string"; isReadonly: true }
         Property { name: "vendorVersion"; type: "string"; isReadonly: true }
-        Signal { name: "storageChanged" }
-        Method { name: "totalDiskSpace"; type: "qlonglong" }
-        Method { name: "availableDiskSpace"; type: "qlonglong" }
-        Method { name: "diskUsageModel"; type: "QVariant" }
-        Method { name: "refreshStorageModels" }
     }
     Component {
         name: "AlarmToneModel"


### PR DESCRIPTION
This pulls in Udisks setup to many places which otherwise just want
some basic os naming. Not spotting any real usage anymore when there's
also explicit partition model api available these days.

@Tomin1 @adenexter @rainemak 