### PR TITLE
[deviceinfo] Add os and firmware information properties. JB#57114

### DIFF
--- a/rpm/nemo-qml-plugin-systemsettings.spec
+++ b/rpm/nemo-qml-plugin-systemsettings.spec
@@ -29,7 +29,7 @@ BuildRequires:  pkgconfig(libcrypto)
 BuildRequires:  pkgconfig(nemodbus) >= 2.1.16
 BuildRequires:  pkgconfig(libsailfishkeyprovider) >= 0.0.14
 BuildRequires:  pkgconfig(connman-qt5) >= 1.2.38
-BuildRequires:  pkgconfig(ssu-sysinfo) >= 1.1.0
+BuildRequires:  pkgconfig(ssu-sysinfo) >= 1.4.0
 BuildRequires:  pkgconfig(packagekitqt5)
 BuildRequires:  pkgconfig(glib-2.0)
 BuildRequires:  pkgconfig(sailfishaccesscontrol)

--- a/src/deviceinfo.cpp
+++ b/src/deviceinfo.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Jolla Ltd. <simo.piiroinen@jollamobile.com>
+ * Copyright (c) 2017 - 2022 Jolla Ltd.
  *
  * You may use this file under the terms of the BSD license as follows:
  *
@@ -48,6 +48,9 @@ public:
     QString m_designation;
     QString m_manufacturer;
     QString m_prettyName;
+    QString m_osName;
+    QString m_osVersion;
+    QString m_adaptationVersion;
 };
 
 DeviceInfoPrivate::DeviceInfoPrivate()
@@ -76,6 +79,9 @@ DeviceInfoPrivate::DeviceInfoPrivate()
     m_designation = ssusysinfo_device_designation(si);
     m_manufacturer = ssusysinfo_device_manufacturer(si);
     m_prettyName = ssusysinfo_device_pretty_name(si);
+    m_osName = ssusysinfo_os_name(si);
+    m_osVersion = ssusysinfo_os_version(si);
+    m_adaptationVersion = ssusysinfo_hw_version(si);
 
     ssusysinfo_delete(si);
 }
@@ -136,4 +142,22 @@ QString DeviceInfo::prettyName() const
 {
     Q_D(const DeviceInfo);
     return d->m_prettyName;
+}
+
+QString DeviceInfo::osName() const
+{
+    Q_D(const DeviceInfo);
+    return d->m_osName;
+}
+
+QString DeviceInfo::osVersion() const
+{
+    Q_D(const DeviceInfo);
+    return d->m_osVersion;
+}
+
+QString DeviceInfo::adaptationVersion() const
+{
+    Q_D(const DeviceInfo);
+    return d->m_adaptationVersion;
 }

--- a/src/deviceinfo.h
+++ b/src/deviceinfo.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Jolla Ltd. <simo.piiroinen@jollamobile.com>
+ * Copyright (c) 2017 - 2022 Jolla Ltd.
  *
  * You may use this file under the terms of the BSD license as follows:
  *
@@ -48,6 +48,9 @@ class SYSTEMSETTINGS_EXPORT DeviceInfo: public QObject
     Q_PROPERTY(QString designation READ designation CONSTANT)
     Q_PROPERTY(QString manufacturer READ manufacturer CONSTANT)
     Q_PROPERTY(QString prettyName READ prettyName CONSTANT)
+    Q_PROPERTY(QString osName READ osName CONSTANT)
+    Q_PROPERTY(QString osVersion READ osVersion CONSTANT)
+    Q_PROPERTY(QString adaptationVersion READ adaptationVersion CONSTANT)
 
 public:
     enum Feature {
@@ -105,11 +108,117 @@ public:
     Q_INVOKABLE bool hasFeature(DeviceInfo::Feature feature) const;
     Q_INVOKABLE bool hasHardwareKey(Qt::Key key) const;
 
+    /*!
+     * Device model
+     *
+     * Returns values such as:
+     *   "SbJ"
+     *   "tbj"
+     *   "l500d"
+     *   "tk7001"
+     *   "SDK"
+     *   "SDK Target"
+     *   "UNKNOWN"
+     *
+     * Should be functionally equivalent with:
+     *   SsuDeviceInfo::deviceModel()
+     */
     QString model() const;
+
+    /*!
+     * Device base model
+     *
+     * If the device is not an variant and there is no base model,
+     * returns "UNKNOWN" - otherwise return values are similar as
+     * what can be expected from #model().
+     *
+     * Should be functionally equivalent with:
+     *   SsuDeviceInfo::deviceVariant(false)
+     */
     QString baseModel() const;
+
+    /*!
+     * Type designation, like NCC-1701.
+     *
+     * Returns values such as:
+     *   "JP-1301"
+     *   "JT-1501"
+     *   "Aqua Fish"
+     *   "TK7001"
+     *   "UNKNOWN"
+     *
+     * Should be functionally equivalent with:
+     *   SsuDeviceInfo::displayName(Ssu::DeviceDesignation)
+     *   QDeviceInfo::productName()
+     */
     QString designation() const;
+
+    /*!
+     * Manufacturer, like ACME Corp.
+     *
+     * Returns values such as:
+     *   "Jolla"
+     *   "Intex"
+     *   "Turing Robotic Industries"
+     *   "UNKNOWN"
+     *
+     * Should be functionally equivalent with:
+     *   SsuDeviceInfo::displayName(Ssu::DeviceManufacturer)
+     *   QDeviceInfo::manufacturer()
+     */
     QString manufacturer() const;
+
+    /*!
+     * Marketed device name, like Pogoblaster 3000.
+     *
+     * Returns values such as:
+     *   "Jolla"
+     *   "Jolla Tablet"
+     *   "Intex Aqua Fish"
+     *   "Turing Phone"
+     *   "UNKNOWN"
+     *
+     * Should be functionally equivalent with:
+     *   SsuDeviceInfo::displayName(Ssu::Ssu::DeviceModel)
+     *   QDeviceInfo::model()
+     */
     QString prettyName() const;
+
+    /*!
+     * Operating system name
+     *
+     * Returns values such as:
+     *   "Sailfish OS"
+     *   "UNKNOWN"
+     *
+     * Should be functionally equivalent with:
+     *   QDeviceInfo::operatingSystemName()
+     */
+    QString osName() const;
+
+    /*!
+     * Operating system version
+     *
+     * Returns values such as:
+     *   "4.2.0.10"
+     *   "UNKNOWN"
+     *
+     * Should be functionally equivalent with:
+     *   QDeviceInfo::version(Os)
+     */
+    QString osVersion() const;
+
+    /*!
+     * Hardware adaptation version
+     *
+     * Returns values such as:
+     *   "4.2.0.10"
+     *   "UNKNOWN"
+     *
+     * Should be functionally equivalent with:
+     *   QDeviceInfo::version(Firmware)
+     */
+    QString adaptationVersion() const;
 
 private:
 


### PR DESCRIPTION
Allows lightweight access to os / firmare version information without
using custom /etc/*-release parsers.

Signed-off-by: Simo Piiroinen <simo.piiroinen@jollamobile.com>