### PR TITLE
[deviceinfo] Add uniqueDeviceID property. JB#56949

### DIFF
--- a/src/deviceinfo.h
+++ b/src/deviceinfo.h
@@ -52,6 +52,7 @@ class SYSTEMSETTINGS_EXPORT DeviceInfo: public QObject
     Q_PROPERTY(QString osVersion READ osVersion CONSTANT)
     Q_PROPERTY(QString adaptationVersion READ adaptationVersion CONSTANT)
     Q_PROPERTY(QStringList imeiNumbers READ imeiNumbers NOTIFY imeiNumbersChanged)
+    Q_PROPERTY(QString uniqueDeviceID READ uniqueDeviceID CONSTANT)
 
 public:
     enum Feature {
@@ -249,6 +250,14 @@ public:
      *   QDeviceInfo::imeiCount()
      */
     QStringList imeiNumbers();
+
+    /*!
+     * Unique device identifier
+     *
+     * Should be functionally equivalent with:
+     *   QDeviceInfo::uniqueDeviceID()
+     */
+    QString uniqueDeviceID();
 
 Q_SIGNALS:
     void imeiNumbersChanged();


### PR DESCRIPTION
As an enabler for deprecating QDeviceInfo class from qt5-qtsysteminfo
package, provide unique device identifier via DeviceInfo class.

Signed-off-by: Simo Piiroinen <simo.piiroinen@jolla.com>