### PR TITLE
[systemsettings] Remove qt5-qtsysteminfo usage. Fixes JB#56948

### DIFF
--- a/rpm/nemo-qml-plugin-systemsettings.spec
+++ b/rpm/nemo-qml-plugin-systemsettings.spec
@@ -16,7 +16,6 @@ Requires:       udisks2 >= 2.8.1+git6
 Requires:       mlite-qt5 >= 0.3.6
 Requires(post): coreutils
 BuildRequires:  pkgconfig(Qt5Qml)
-BuildRequires:  pkgconfig(Qt5SystemInfo)
 BuildRequires:  pkgconfig(Qt5Test)
 BuildRequires:  pkgconfig(Qt5XmlPatterns)
 BuildRequires:  pkgconfig(timed-qt5)

--- a/src/aboutsettings.cpp
+++ b/src/aboutsettings.cpp
@@ -35,9 +35,6 @@
 #include <QDebug>
 #include <QStringList>
 
-#include <QNetworkInfo>
-
-#include <QDeviceInfo>
 #include <QFile>
 #include <QByteArray>
 #include <QRegularExpression>
@@ -157,13 +154,14 @@ void parseLocalizationFile(const QString &filename, QMap<QString, QString> *resu
 
 AboutSettingsPrivate::AboutSettingsPrivate(QObject *parent)
     : QObject(parent)
+    , deviceInfo(new DeviceInfo())
 {
-
 }
 
 AboutSettingsPrivate::~AboutSettingsPrivate()
 {
-
+    delete deviceInfo;
+    deviceInfo = nullptr;
 }
 
 
@@ -184,19 +182,11 @@ AboutSettings::~AboutSettings()
 QString AboutSettings::wlanMacAddress() const
 {
     Q_D(const AboutSettings);
-    return d->networkInfo.macAddress(QNetworkInfo::WlanMode, 0);
-}
-
-QString AboutSettings::imei() const
-{
-    Q_D(const AboutSettings);
-    return d->deviceInfo.imei(0);
+    return d->deviceInfo->wlanMacAddress();
 }
 
 QString AboutSettings::serial() const
 {
-    // TODO: eventually we should use QDeviceInfo's uniqueDeviceID()
-
     QStringList serialFiles;
 
     serialFiles

--- a/src/aboutsettings.h
+++ b/src/aboutsettings.h
@@ -45,7 +45,6 @@ class SYSTEMSETTINGS_EXPORT AboutSettings: public QObject
     Q_OBJECT
 
     Q_PROPERTY(QString wlanMacAddress READ wlanMacAddress CONSTANT)
-    Q_PROPERTY(QString imei READ imei CONSTANT)
     Q_PROPERTY(QString serial READ serial CONSTANT)
     Q_PROPERTY(QString localizedOperatingSystemName READ localizedOperatingSystemName CONSTANT)
     Q_PROPERTY(QString baseOperatingSystemName READ baseOperatingSystemName CONSTANT)
@@ -62,7 +61,6 @@ public:
     virtual ~AboutSettings();
 
     QString wlanMacAddress() const;
-    QString imei() const;
     QString serial() const;
     QString localizedOperatingSystemName() const;
     QString baseOperatingSystemName() const;

--- a/src/aboutsettings_p.h
+++ b/src/aboutsettings_p.h
@@ -33,9 +33,9 @@
 #define ABOUTSETTINGS_P_H
 
 #include <QObject>
-#include <QNetworkInfo>
-#include <QDeviceInfo>
 #include <QVariantList>
+
+#include "deviceinfo.h"
 
 class AboutSettingsPrivate : public QObject
 {
@@ -45,8 +45,7 @@ public:
     AboutSettingsPrivate(QObject *parent = nullptr);
     virtual ~AboutSettingsPrivate();
 
-    QNetworkInfo networkInfo;
-    QDeviceInfo deviceInfo;
+    DeviceInfo *deviceInfo;
 
     mutable QMap<QString, QString> osRelease;
     mutable QMap<QString, QString> osReleaseLocalization;

--- a/src/deviceinfo.h
+++ b/src/deviceinfo.h
@@ -52,6 +52,7 @@ class SYSTEMSETTINGS_EXPORT DeviceInfo: public QObject
     Q_PROPERTY(QString osVersion READ osVersion CONSTANT)
     Q_PROPERTY(QString adaptationVersion READ adaptationVersion CONSTANT)
     Q_PROPERTY(QStringList imeiNumbers READ imeiNumbers NOTIFY imeiNumbersChanged)
+    Q_PROPERTY(QString wlanMacAddress READ wlanMacAddress CONSTANT)
 
 public:
     enum Feature {
@@ -249,6 +250,14 @@ public:
      *   QDeviceInfo::imeiCount()
      */
     QStringList imeiNumbers();
+
+    /*!
+     * Get wlan mac address
+     *
+     * Note: Interface availability is cached on the first call, but
+     *       mac address itself is re-read from sysfs on every call.
+     */
+    QString wlanMacAddress();
 
 Q_SIGNALS:
     void imeiNumbersChanged();

--- a/src/plugin/plugins.qmltypes
+++ b/src/plugin/plugins.qmltypes
@@ -14,7 +14,6 @@ Module {
         exports: ["org.nemomobile.systemsettings/AboutSettings 1.0"]
         exportMetaObjectRevisions: [0]
         Property { name: "wlanMacAddress"; type: "string"; isReadonly: true }
-        Property { name: "imei"; type: "string"; isReadonly: true }
         Property { name: "serial"; type: "string"; isReadonly: true }
         Property { name: "localizedOperatingSystemName"; type: "string"; isReadonly: true }
         Property { name: "baseOperatingSystemName"; type: "string"; isReadonly: true }
@@ -236,6 +235,11 @@ Module {
         Property { name: "designation"; type: "string"; isReadonly: true }
         Property { name: "manufacturer"; type: "string"; isReadonly: true }
         Property { name: "prettyName"; type: "string"; isReadonly: true }
+        Property { name: "osName"; type: "string"; isReadonly: true }
+        Property { name: "osVersion"; type: "string"; isReadonly: true }
+        Property { name: "adaptationVersion"; type: "string"; isReadonly: true }
+        Property { name: "imeiNumbers"; type: "QStringList"; isReadonly: true }
+        Property { name: "wlanMacAddress"; type: "string"; isReadonly: true }
         Method {
             name: "hasFeature"
             type: "bool"

--- a/src/src.pro
+++ b/src/src.pro
@@ -2,7 +2,7 @@ TEMPLATE = lib
 TARGET = systemsettings
 
 CONFIG += qt create_pc create_prl no_install_prl c++11
-QT += qml dbus systeminfo xmlpatterns
+QT += qml dbus xmlpatterns
 QT -= gui
 
 CONFIG += c++11 hide_symbols link_pkgconfig

--- a/tests/tests.pro
+++ b/tests/tests.pro
@@ -2,7 +2,7 @@
 
 PACKAGENAME = nemo-qml-plugin-systemsettings
 
-QT += testlib qml dbus systeminfo
+QT += testlib qml dbus
 QT -= gui
 
 TEMPLATE = app


### PR DESCRIPTION
Add DeviceInfo::wlanMacAddress().

Change AboutSettings::wlanMacAddress() so that it uses DeviceInfo
instead of QNetworkinfo.

Remove AboutSettings::imei() as it has not been in active use since
introduction of dual sim support and it relies on QDeviceInfo.

Remove qt5-qtsysteminfo build dependencies.

Signed-off-by: Simo Piiroinen <simo.piiroinen@jolla.com>