### PR TITLE
[battery] Add chargingSuspendable qml property. JB#59152

### DIFF
--- a/rpm/nemo-qml-plugin-systemsettings.spec
+++ b/rpm/nemo-qml-plugin-systemsettings.spec
@@ -8,7 +8,7 @@ Source0:    %{name}-%{version}.tar.bz2
 Requires(post): /sbin/ldconfig
 Requires(postun): /sbin/ldconfig
 Requires:       connman
-Requires:       mce >= 1.112.0
+Requires:       mce >= 1.113.0
 Requires:       libsailfishkeyprovider >= 0.0.14
 Requires:       connman-qt5 >= 1.2.38
 Requires:       user-managerd >= 0.4.0
@@ -20,7 +20,7 @@ BuildRequires:  pkgconfig(Qt5Test)
 BuildRequires:  pkgconfig(Qt5XmlPatterns)
 BuildRequires:  pkgconfig(timed-qt5)
 BuildRequires:  pkgconfig(profile)
-BuildRequires:  pkgconfig(mce) >= 1.31.0
+BuildRequires:  pkgconfig(mce) >= 1.32.0
 BuildRequires:  pkgconfig(mlite5) >= 0.3.6
 BuildRequires:  pkgconfig(usb-moded-qt5)
 BuildRequires:  pkgconfig(blkid)

--- a/src/batterystatus.h
+++ b/src/batterystatus.h
@@ -49,6 +49,8 @@ class SYSTEMSETTINGS_EXPORT BatteryStatus : public QObject
             NOTIFY chargingModeChanged)
     Q_PROPERTY(bool chargingForced READ chargingForced WRITE setChargingForced
             NOTIFY chargingForcedChanged)
+    Q_PROPERTY(bool chargingSuspendendable READ chargingSuspendendable
+               NOTIFY chargingSuspendableChanged)
     Q_PROPERTY(ChargerStatus chargerStatus READ chargerStatus NOTIFY chargerStatusChanged)
     Q_PROPERTY(int chargePercentage READ chargePercentage NOTIFY chargePercentageChanged)
     Q_PROPERTY(int chargeEnableLimit READ chargeEnableLimit WRITE setChargeEnableLimit
@@ -87,6 +89,7 @@ public:
 
     ChargingMode chargingMode() const;
     bool chargingForced() const;
+    bool chargingSuspendendable() const;
     void setChargingMode(ChargingMode mode);
     void setChargingForced(bool forced);
     ChargerStatus chargerStatus() const;
@@ -100,6 +103,7 @@ public:
 signals:
     void chargingModeChanged(ChargingMode mode);
     void chargingForcedChanged(bool forced);
+    void chargingSuspendableChanged(bool forced);
     void chargerStatusChanged(ChargerStatus status);
     void chargePercentageChanged(int percentage);
     void chargeEnableLimitChanged(int percentage);

--- a/src/batterystatus_p.h
+++ b/src/batterystatus_p.h
@@ -54,6 +54,8 @@ public:
     int chargingModeToInt(BatteryStatus::ChargingMode mode);
     BatteryStatus::ChargerStatus parseChargerStatus(const QString &state);
     BatteryStatus::Status parseBatteryStatus(const QString &status);
+    void chargingSuspendabledRefresh();
+    void chargingSuspendableChanged(bool supported);
 
     BatteryStatus *q;
     BatteryStatus::Status status;
@@ -63,6 +65,7 @@ public:
     int chargeEnableLimit;
     int chargeDisableLimit;
     bool chargingForced;
+    bool chargingSuspendendable;
 
 public slots:
     void mceRegistered();


### PR DESCRIPTION
Add chargingSuspendable battery property. Value is queried from mce on initialization and updated when mce service restart is seen.

Required D-Bus constants are in mce-dev >= 1.32.0 and D-Bus method call itself is implemented in mce >= 1.113.0

Signed-off-by: Simo Piiroinen <simo.piiroinen@jolla.com>