### PR TITLE
Hide external libraries (except connman-qt5) from public api. JB#61655

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.o
 Makefile
 moc_*
+*.moc
 RPMS/
 documentation.list
 src/connmanvpnconnectionproxy.cpp

--- a/rpm/nemo-qml-plugin-systemsettings.spec
+++ b/rpm/nemo-qml-plugin-systemsettings.spec
@@ -44,7 +44,6 @@ BuildRequires:  pkgconfig(qofono-qt5) >= 0.105
 %package devel
 Summary:    System settings C++ library
 Requires:   %{name} = %{version}-%{release}
-Requires:   pkgconfig(nemodbus)
 
 %description devel
 %{summary}.

--- a/src/datetimesettings.h
+++ b/src/datetimesettings.h
@@ -35,15 +35,12 @@
 #include <QObject>
 #include <QTime>
 
-#include <timed-qt5/interface>
-#include <timed-qt5/wallclock>
-
 #include <systemsettingsglobal.h>
+class DateTimeSettingsPrivate;
 
 class SYSTEMSETTINGS_EXPORT DateTimeSettings: public QObject
 {
     Q_OBJECT
-
     Q_ENUMS(HourMode)
     Q_PROPERTY(bool ready READ ready NOTIFY readyChanged)
     Q_PROPERTY(bool automaticTimeUpdate READ automaticTimeUpdate WRITE setAutomaticTimeUpdate NOTIFY automaticTimeUpdateChanged)
@@ -82,23 +79,8 @@ signals:
     void automaticTimezoneUpdateChanged();
     void timezoneChanged();
 
-private slots:
-    void onTimedSignal(const Maemo::Timed::WallClock::Info &info, bool time_changed);
-    void onGetWallClockInfoFinished(QDBusPendingCallWatcher *watcher);
-    void onWallClockSettingsFinished(QDBusPendingCallWatcher *watcher);
-
 private:
-    bool setTime(time_t time);
-    bool setSettings(Maemo::Timed::WallClock::Settings &s);
-    void updateTimedInfo();
-
-private:
-    Maemo::Timed::Interface m_timed;
-    QString m_timezone;
-    bool m_autoSystemTime;
-    bool m_autoTimezone;
-    bool m_timedInfoValid;
-    Maemo::Timed::WallClock::Info m_timedInfo;
+    DateTimeSettingsPrivate *d_ptr;
 };
 
 #endif

--- a/src/developermodesettings.h
+++ b/src/developermodesettings.h
@@ -37,14 +37,8 @@
 #include <QObject>
 
 #include <systemsettingsglobal.h>
-#include <daemon.h>
 
-#include <nemo-dbus/connection.h>
-#include <nemo-dbus/interface.h>
-
-QT_BEGIN_NAMESPACE
-class QDBusPendingCallWatcher;
-QT_END_NAMESPACE
+class DeveloperModeSettingsPrivate;
 
 class SYSTEMSETTINGS_EXPORT DeveloperModeSettings : public QObject
 {
@@ -105,44 +99,8 @@ signals:
     void debugHomeEnabledChanged();
     void installationTypeChanged();
 
-private slots:
-    void reportTransactionErrorCode(PackageKit::Transaction::Error code, const QString &details);
-    void updateState(int percentage, PackageKit::Transaction::Status status, PackageKit::Transaction::Role role);
-
 private:
-    enum Command {
-        InstallCommand,
-        RemoveCommand
-    };
-
-    void resetState();
-    void setWorkStatus(Status status);
-    void refreshPackageCacheAndInstall();
-    void resolveAndExecute(Command command);
-    bool installAndRemove(Command command);
-    void connectCommandSignals(PackageKit::Transaction *transaction);
-    void setInstallationType(InstallationType type);
-
-    QString usbModedGetConfig(const QString &key, const QString &fallback);
-    void usbModedSetConfig(const QString &key, const QString &value);
-
-    NemoDBus::Connection m_connection;
-    NemoDBus::Interface m_usbModeDaemon;
-    QString m_wlanIpAddress;
-    QString m_usbInterface;
-    QString m_usbIpAddress;
-    QString m_username;
-    QString m_packageId;
-    bool m_developerModeEnabled;
-    DeveloperModeSettings::Status m_workStatus;
-    int m_workProgress;
-    PackageKit::Transaction::Role m_transactionRole;
-    PackageKit::Transaction::Status m_transactionStatus;
-    bool m_refreshedForInstall;
-    bool m_localInstallFailed;
-    QString m_localDeveloperModePackagePath;
-    bool m_debugHomeEnabled;
-    DeveloperModeSettings::InstallationType m_installationType;
+    DeveloperModeSettingsPrivate *d_ptr;
 };
 
 Q_DECLARE_METATYPE(DeveloperModeSettings::Status)

--- a/src/src.pro
+++ b/src/src.pro
@@ -108,6 +108,6 @@ QMAKE_PKGCONFIG_DESCRIPTION = System settings application development files
 QMAKE_PKGCONFIG_LIBDIR = $$target.path
 QMAKE_PKGCONFIG_INCDIR = $$develheaders.path
 QMAKE_PKGCONFIG_DESTDIR = pkgconfig
-QMAKE_PKGCONFIG_REQUIRES = Qt5Core Qt5DBus profile libsailfishkeyprovider connman-qt5 nemodbus
+QMAKE_PKGCONFIG_REQUIRES = Qt5Core Qt5DBus connman-qt5
 
 INSTALLS += target develheaders pkgconfig locationconfig compat_locationconfig

--- a/src/src.pro
+++ b/src/src.pro
@@ -1,11 +1,11 @@
 TEMPLATE = lib
 TARGET = systemsettings
 
-CONFIG += qt create_pc create_prl no_install_prl c++11
+CONFIG += qt create_pc create_prl no_install_prl
 QT += qml dbus xmlpatterns
 QT -= gui
 
-CONFIG += c++11 hide_symbols link_pkgconfig
+CONFIG += hide_symbols link_pkgconfig
 PKGCONFIG += profile mlite5 mce timed-qt5 blkid libcrypto libsailfishkeyprovider connman-qt5 glib-2.0
 PKGCONFIG += ssu-sysinfo nemodbus packagekitqt5 libsystemd sailfishusermanager sailfishaccesscontrol
 PKGCONFIG += qofono-qt5

--- a/src/udisks2block_p.h
+++ b/src/udisks2block_p.h
@@ -33,8 +33,6 @@
 #ifndef UDISKS2_BLOCK_H
 #define UDISKS2_BLOCK_H
 
-#include <nemo-dbus/connection.h>
-
 #include <QObject>
 #include <QVariantMap>
 #include <QPointer>
@@ -45,9 +43,10 @@
 #include "udisks2defines.h"
 
 class QDBusPendingCallWatcher;
+class QDBusMessage;
+class BlockPrivate;
 
 namespace UDisks2 {
-
 
 class SYSTEMSETTINGS_EXPORT Block : public QObject
 {
@@ -147,27 +146,9 @@ private:
 
     void rescan(const QString &dbusObjectPath);
 
-    QString m_path;
-    UDisks2::InterfacePropertyMap m_interfacePropertyMap;
-    QVariantMap m_data;
-    QVariantMap m_drive;
-    NemoDBus::Connection m_connection;
-    QString m_mountPath;
-    bool m_mountable;
-    bool m_encrypted;
-    bool m_formatting;
-    bool m_locking;
-
-    bool m_overrideHintAuto = false;
-
-    bool m_pendingFileSystem = false;
-    bool m_pendingBlock = false;
-    bool m_pendingEncrypted = false;
-    bool m_pendingDrive = false;
-    bool m_pendingPartition = false;
-    bool m_pendingPartitionTable = false;
-
     friend class BlockDevices;
+
+    BlockPrivate *d_ptr;
 };
 
 }

--- a/src/userinfo.h
+++ b/src/userinfo.h
@@ -56,6 +56,7 @@ class SYSTEMSETTINGS_EXPORT UserInfo: public QObject
     Q_PROPERTY(bool watched READ watched WRITE setWatched NOTIFY watchedChanged)
 
     friend class UserModel;
+    friend class UserModelPrivate;
 
 public:
     enum UserType {

--- a/src/usermodel.h
+++ b/src/usermodel.h
@@ -41,10 +41,8 @@
 #include "systemsettingsglobal.h"
 #include "userinfo.h"
 
-#include <nemo-dbus/interface.h>
-
-class QDBusServiceWatcher;
 struct SailfishUserManagerEntry;
+class UserModelPrivate;
 
 class SYSTEMSETTINGS_EXPORT UserModel: public QAbstractListModel
 {
@@ -136,25 +134,9 @@ signals:
     void removeGroupsFailed(int row, int error);
     void setGuestEnabledFailed(bool enabling, int error);
 
-private slots:
-    void onUserAdded(const SailfishUserManagerEntry &entry);
-    void onUserModified(uint uid, const QString &newName);
-    void onUserRemoved(uint uid);
-    void onCurrentUserChanged(uint uid);
-    void onCurrentUserChangeFailed(uint uid);
-    void onGuestUserEnabled(bool enabled);
-
-    void createInterface();
-    void destroyInterface();
-
 private:
-    void add(UserInfo &user);
+    UserModelPrivate *d_ptr;
 
-    QVector<UserInfo> m_users;
-    QHash<uint, int> m_uidsToRows;
-    QSet<uint> m_transitioning;
-    NemoDBus::Interface *m_dBusInterface;
-    QDBusServiceWatcher *m_dBusWatcher;
-    bool m_guestEnabled;
+    friend class UserModelPrivate;
 };
 #endif /* USERMODEL_H */


### PR DESCRIPTION
Pimplified some classes which where exposing external library content on the headers in order not to require depending project a) linking also to those libraries, and b) requiring the external library header files to be present when compiling them (that seemed working by accident except for nemo-dbus).

Sorry for code churn here, but it's mostly just moving stuff around and sprinkling some d_ptr-> here and there.