### PR TITLE
[nemo-systemsettings] Avoid unnecessary qt dependencies. JB#61733

### DIFF
--- a/rpm/nemo-qml-plugin-systemsettings.spec
+++ b/rpm/nemo-qml-plugin-systemsettings.spec
@@ -16,7 +16,7 @@ Requires:       udisks2 >= 2.8.1+git6
 Requires:       mlite-qt5 >= 0.3.6
 Requires(post): coreutils
 BuildRequires:  pkgconfig(Qt5Qml)
-BuildRequires:  pkgconfig(Qt5XmlPatterns)
+BuildRequires:  pkgconfig(Qt5Network)
 BuildRequires:  pkgconfig(timed-qt5)
 BuildRequires:  pkgconfig(profile)
 BuildRequires:  pkgconfig(mce) >= 1.32.0

--- a/src/displaysettings.h
+++ b/src/displaysettings.h
@@ -33,7 +33,6 @@
 #define DISPLAYSETTINGS_H
 
 #include <QObject>
-#include <QtQml>
 #include <QDBusPendingCallWatcher>
 
 class ComNokiaMceRequestInterface;
@@ -187,7 +186,5 @@ private:
     int m_powerSaveModeThreshold;
     bool m_populated;
 };
-
-QML_DECLARE_TYPE(DisplaySettings)
 
 #endif

--- a/src/partitionmodel.cpp
+++ b/src/partitionmodel.cpp
@@ -36,7 +36,6 @@
 
 #include <QDir>
 #include <QFileInfo>
-#include <QtQml/qqmlinfo.h>
 
 PartitionModel::PartitionModel(QObject *parent)
     : QAbstractListModel(parent)
@@ -166,7 +165,7 @@ void PartitionModel::format(const QString &devicePath, const QVariantMap &argume
 {
     QString filesystemType = arguments.value(QLatin1String("filesystemType"), QString()).toString();
     if (filesystemType.isEmpty()) {
-        qmlInfo(this) << "Missing or empty filesystemType argument, cannot format.";
+        qCWarning(lcMemoryCardLog) << "Missing or empty filesystemType argument, cannot format.";
         return;
     }
 

--- a/src/src.pro
+++ b/src/src.pro
@@ -2,7 +2,7 @@ TEMPLATE = lib
 TARGET = systemsettings
 
 CONFIG += qt create_pc create_prl no_install_prl
-QT += qml dbus xmlpatterns
+QT += dbus network
 QT -= gui
 
 CONFIG += hide_symbols link_pkgconfig


### PR DESCRIPTION
The lib doesn't really use qml anymore nor xml patterns. QNetwork does get used in deviceinfo but that was implicitly pulled in.