### PR TITLE
Udisks2 integration fixes and cleanups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,4 @@ src/mceiface.h
 src/pkgconfig/
 src/plugin/libnemosystemsettings.so
 src/plugin/plugin.moc
-
+setlocale/setlocale

--- a/src/deviceinfo.cpp
+++ b/src/deviceinfo.cpp
@@ -251,7 +251,8 @@ const QStringList &DeviceInfoPrivate::networkModeDirectoryList(DeviceInfoPrivate
         else if (mode == DeviceInfoPrivate::EthernetMode)
             stemList << QStringLiteral("eth") << QStringLiteral("usb") << QStringLiteral("rndis");
         for (auto stemIter = stemList.cbegin(); stemIter != stemList.cend(); ++stemIter) {
-            QFileInfoList modeDirList(baseDir.entryInfoList(QStringList() << QStringLiteral("%1*").arg(*stemIter), QDir::Dirs, QDir::Name));
+            QFileInfoList modeDirList(baseDir.entryInfoList(QStringList() << QStringLiteral("%1*").arg(*stemIter),
+                                                            QDir::Dirs, QDir::Name));
             for (auto modeDirIter = modeDirList.cbegin(); modeDirIter != modeDirList.cend(); ++modeDirIter)
                 modeDirectoryList.append((*modeDirIter).filePath());
         }

--- a/src/partitionmanager.cpp
+++ b/src/partitionmanager.cpp
@@ -90,7 +90,7 @@ PartitionManagerPrivate::PartitionManagerPrivate()
 
     // Remove any prospective internal partitions that aren't mounted.
     int internalPartitionCount = 0;
-    for (Partitions::iterator it = m_partitions.begin(); it != m_partitions.end();) {
+    for (PartitionList::iterator it = m_partitions.begin(); it != m_partitions.end();) {
         auto partition = *it;
 
         if (partition->storageType & Partition::Internal) {
@@ -171,12 +171,12 @@ void PartitionManagerPrivate::add(QExplicitlySharedDataPointer<PartitionPrivate>
     }
 
     m_partitions.insert(insertIndex, partition);
-    Partitions addedPartitions = { partition };
+    PartitionList addedPartitions = { partition };
     refresh(addedPartitions, addedPartitions);
     emit partitionAdded(Partition(partition));
 }
 
-void PartitionManagerPrivate::remove(const Partitions &partitions)
+void PartitionManagerPrivate::remove(const PartitionList &partitions)
 {
     for (const auto removedPartition : partitions) {
         for (int i = m_partitions.count() - 1; i >= 0 && m_partitions.at(i)->storageType == Partition::External; --i) {
@@ -192,7 +192,7 @@ void PartitionManagerPrivate::remove(const Partitions &partitions)
 
 void PartitionManagerPrivate::refresh()
 {
-    Partitions changedPartitions;
+    PartitionList changedPartitions;
     for (int index = 0; index < m_partitions.count(); ++index) {
         const auto partition = m_partitions.at(index);
         if (partition->storageType == Partition::External) {
@@ -208,13 +208,13 @@ void PartitionManagerPrivate::refresh()
 
 void PartitionManagerPrivate::refresh(PartitionPrivate *partition)
 {
-    refresh(Partitions() << QExplicitlySharedDataPointer<PartitionPrivate>(partition),
-            Partitions() << QExplicitlySharedDataPointer<PartitionPrivate>(partition));
+    refresh(PartitionList() << QExplicitlySharedDataPointer<PartitionPrivate>(partition),
+            PartitionList() << QExplicitlySharedDataPointer<PartitionPrivate>(partition));
 
     emit partitionChanged(Partition(QExplicitlySharedDataPointer<PartitionPrivate>(partition)));
 }
 
-void PartitionManagerPrivate::refresh(const Partitions &partitions, Partitions &changedPartitions)
+void PartitionManagerPrivate::refresh(const PartitionList &partitions, PartitionList &changedPartitions)
 {
     for (auto partition : partitions) {
         // Reset properties to the unmounted defaults.  If the partition is mounted these will be restored

--- a/src/partitionmanager.cpp
+++ b/src/partitionmanager.cpp
@@ -282,6 +282,7 @@ void PartitionManagerPrivate::refresh(const Partitions &partitions, Partitions &
                     && quota.dqb_bsoftlimit != 0)
                 quotaAvailable = std::max((qint64)dbtob(quota.dqb_bsoftlimit) - (qint64)quota.dqb_curspace, 0LL);
 
+            // FIXME JB#56182: statvfs64() may block for a long time so would better be done in separate thread.
             struct statvfs64 stat;
             if (::statvfs64(partition->mountPath.toUtf8().constData(), &stat) == 0) {
                 partition->bytesTotal = stat.f_blocks * stat.f_frsize;

--- a/src/partitionmanager.cpp
+++ b/src/partitionmanager.cpp
@@ -208,7 +208,8 @@ void PartitionManagerPrivate::refresh()
 
 void PartitionManagerPrivate::refresh(PartitionPrivate *partition)
 {
-    refresh(Partitions() << QExplicitlySharedDataPointer<PartitionPrivate>(partition), Partitions() << QExplicitlySharedDataPointer<PartitionPrivate>(partition));
+    refresh(Partitions() << QExplicitlySharedDataPointer<PartitionPrivate>(partition),
+            Partitions() << QExplicitlySharedDataPointer<PartitionPrivate>(partition));
 
     emit partitionChanged(Partition(QExplicitlySharedDataPointer<PartitionPrivate>(partition)));
 }
@@ -246,8 +247,9 @@ void PartitionManagerPrivate::refresh(const Partitions &partitions, Partitions &
         const QString deviceName = devicePath.section(QChar('/'), 2);
 
         for (auto partition : partitions) {
-            if (partition->valid || ((partition->status == Partition::Mounted || partition->status == Partition::Mounting) &&
-                                     (partition->storageType != Partition::External))) {
+            if (partition->valid
+                    || ((partition->status == Partition::Mounted || partition->status == Partition::Mounting)
+                        && (partition->storageType != Partition::External))) {
                 continue;
             }
 

--- a/src/partitionmanager_p.h
+++ b/src/partitionmanager_p.h
@@ -48,7 +48,7 @@ class PartitionManagerPrivate : public QObject, public QSharedData
 {
     Q_OBJECT
 public:
-    typedef QVector<QExplicitlySharedDataPointer<PartitionPrivate>> Partitions;
+    typedef QVector<QExplicitlySharedDataPointer<PartitionPrivate>> PartitionList;
 
     PartitionManagerPrivate();
     ~PartitionManagerPrivate();
@@ -59,11 +59,11 @@ public:
     QVector<Partition> partitions(Partition::StorageTypes types) const;
 
     void add(QExplicitlySharedDataPointer<PartitionPrivate> partition);
-    void remove(const Partitions &partitions);
+    void remove(const PartitionList &partitions);
 
     void refresh();
     void refresh(PartitionPrivate *partition);
-    void refresh(const Partitions &partitions, Partitions &changedPartitions);
+    void refresh(const PartitionList &partitions, PartitionList &changedPartitions);
 
     void lock(const QString &devicePath);
     void unlock(const Partition &partition, const QString &passphrase);
@@ -95,7 +95,7 @@ private:
     // TODO: This is leaking (Disks2::Monitor is never free'ed).
     static PartitionManagerPrivate *sharedInstance;
 
-    Partitions m_partitions;
+    PartitionList m_partitions;
     Partition m_root;
 
     QScopedPointer<UDisks2::Monitor> m_udisksMonitor;

--- a/src/udisks2block.cpp
+++ b/src/udisks2block.cpp
@@ -55,7 +55,8 @@ UDisks2::Block::Block(const QString &path, const UDisks2::InterfacePropertyMap &
                                    << d_ptr->m_connection.connection().lastError().message();
     }
 
-    qCInfo(lcMemoryCardLog) << "Creating a new block. Mountable:" << d_ptr->m_mountable << ", encrypted:" << d_ptr->m_encrypted
+    qCInfo(lcMemoryCardLog) << "Creating a new block. Mountable:" << d_ptr->m_mountable
+                            << ", encrypted:" << d_ptr->m_encrypted
                             << "object path:" << d_ptr->m_path << "data is empty:" << d_ptr->m_data.isEmpty();
 
     if (d_ptr->m_interfacePropertyMap.isEmpty()) {
@@ -379,14 +380,17 @@ bool UDisks2::Block::hasData() const
 
 void UDisks2::Block::dumpInfo() const
 {
-    qCInfo(lcMemoryCardLog) << this << ":" << device() << "Preferred device:" << preferredDevice() << "D-Bus object path:" << path();
-    qCInfo(lcMemoryCardLog) << "- drive:" << drive() << "device number:" << deviceNumber() << "connection bus:" << connectionBus();
+    qCInfo(lcMemoryCardLog) << this << ":" << device() << "Preferred device:" << preferredDevice()
+                            << "D-Bus object path:" << path();
+    qCInfo(lcMemoryCardLog) << "- drive:" << drive() << "device number:" << deviceNumber()
+                            << "connection bus:" << connectionBus();
     qCInfo(lcMemoryCardLog) << "- id:" << id() << "size:" << size();
     qCInfo(lcMemoryCardLog) << "- isreadonly:" << isReadOnly() << "idtype:" << idType();
     qCInfo(lcMemoryCardLog) << "- idversion:" << idVersion() << "idlabel:" << idLabel();
     qCInfo(lcMemoryCardLog) << "- iduuid:" << idUUID();
     qCInfo(lcMemoryCardLog) << "- ismountable:" << isMountable() << "mount path:" << mountPath();
-    qCInfo(lcMemoryCardLog) << "- isencrypted:" << isEncrypted() << "crypto backing device:" << cryptoBackingDevicePath()
+    qCInfo(lcMemoryCardLog) << "- isencrypted:" << isEncrypted()
+                            << "crypto backing device:" << cryptoBackingDevicePath()
                             << "crypto backing object path:" << cryptoBackingDeviceObjectPath();
     qCInfo(lcMemoryCardLog) << "- isformatting:" << isFormatting();
     qCInfo(lcMemoryCardLog) << "- ispartiontable:" << isPartitionTable() << "ispartition:" << isPartition();
@@ -515,11 +519,13 @@ void UDisks2::Block::rescan(const QString &dbusObjectPath)
     QVariantMap options;
     arguments << options;
 
-    NemoDBus::Interface blockDeviceInterface(this, d_ptr->m_connection, UDISKS2_SERVICE, dbusObjectPath, UDISKS2_BLOCK_INTERFACE);
+    NemoDBus::Interface blockDeviceInterface(this, d_ptr->m_connection,
+                                             UDISKS2_SERVICE, dbusObjectPath, UDISKS2_BLOCK_INTERFACE);
     NemoDBus::Response *response = blockDeviceInterface.call(UDISKS2_BLOCK_RESCAN, arguments);
     response->onError([this, dbusObjectPath](const QDBusError &error) {
         qCDebug(lcMemoryCardLog) << "UDisks failed to rescan object path" << dbusObjectPath
-                                 << ", error type:" << error.type() << ", name:" << error.name() << ", message:" << error.message();
+                                 << ", error type:" << error.type() << ", name:" << error.name()
+                                 << ", message:" << error.message();
     });
 }
 
@@ -535,7 +541,8 @@ void UDisks2::Block::getProperties(const QString &path, const QString &interface
 
     *pending = true;
 
-    NemoDBus::Interface dbusPropertyInterface(this, d_ptr->m_connection, UDISKS2_SERVICE, path, DBUS_OBJECT_PROPERTIES_INTERFACE);
+    NemoDBus::Interface dbusPropertyInterface(this, d_ptr->m_connection,
+                                              UDISKS2_SERVICE, path, DBUS_OBJECT_PROPERTIES_INTERFACE);
     NemoDBus::Response *response = dbusPropertyInterface.call(DBUS_GET_ALL, interface);
     response->onFinished<QVariantMap>([this, success](const QVariantMap &values) {
         success(NemoDBus::demarshallArgument<QVariantMap>(values));

--- a/src/udisks2block_p.h
+++ b/src/udisks2block_p.h
@@ -136,7 +136,7 @@ private:
 
     bool isCompleted() const;
 
-    void updateFileSystemInterface(const QVariant &mountPoints);
+    void updateFileSystemInterface(const QVariantMap &filesystemProperties);
     bool clearFormattingState();
 
     void getProperties(const QString &path, const QString &interface,

--- a/src/udisks2blockdevices.cpp
+++ b/src/udisks2blockdevices.cpp
@@ -267,8 +267,9 @@ bool BlockDevices::hintAuto(const QString &devicePath)
 void BlockDevices::blockCompleted()
 {
     Block *completedBlock = qobject_cast<Block *>(sender());
-    if (completedBlock->isValid() && (completedBlock->isPartitionTable() ||
-                                      (completedBlock->hasInterface(UDISKS2_BLOCK_INTERFACE) && completedBlock->interfaceCount() == 1)) ){
+    if (completedBlock->isValid() && (completedBlock->isPartitionTable()
+                                      || (completedBlock->hasInterface(UDISKS2_BLOCK_INTERFACE)
+                                          && completedBlock->interfaceCount() == 1))) {
         qCInfo(lcMemoryCardLog) << "Start waiting for block" << completedBlock->device();
         waitPartition(completedBlock);
         updatePopulatedCheck();
@@ -379,7 +380,11 @@ void BlockDevices::complete(Block *block, bool forceAccept)
         });
     }
 
-    bool willAccept = !unlocked && (block->isPartition() || block->isMountable() || block->isEncrypted() || block->isFormatting() || forceAccept);
+    bool willAccept = !unlocked && (block->isPartition()
+                                    || block->isMountable()
+                                    || block->isEncrypted()
+                                    || block->isFormatting()
+                                    || forceAccept);
     qCInfo(lcMemoryCardLog) << "Completed block" << qPrintable(block->path())
                             << "is" << (willAccept ? "accepted" : block->isPartition() ? "kept" : "rejected");
     block->dumpInfo();

--- a/src/udisks2blockdevices_p.h
+++ b/src/udisks2blockdevices_p.h
@@ -79,7 +79,6 @@ public:
 
     void dumpBlocks() const;
 
-
 signals:
     void newBlock(Block *block, bool createPartition);
     void externalStoragesPopulated();
@@ -88,7 +87,6 @@ private slots:
     void blockCompleted();
 
 private:
-
     struct PartitionWaiter {
         PartitionWaiter(int timer, Block *block);
         ~PartitionWaiter();

--- a/src/udisks2job.cpp
+++ b/src/udisks2job.cpp
@@ -54,10 +54,12 @@ UDisks2::Job::Job(const QString &path, const QVariantMap &data, QObject *parent)
                 QStringLiteral("Completed"),
                 this,
                 SLOT(updateCompleted(bool, QString)))) {
-        qCWarning(lcMemoryCardLog) << "Failed to connect to Job's at path" << qPrintable(m_path) << "completed signal" << qPrintable(m_connection.lastError().message());
+        qCWarning(lcMemoryCardLog) << "Failed to connect to Job's at path" << qPrintable(m_path)
+                                   << "completed signal" << qPrintable(m_connection.lastError().message());
     }
 
-    connect(Monitor::instance(), &Monitor::errorMessage, this, [this](const QString &objectPath, const QString &errorName) {
+    connect(Monitor::instance(), &Monitor::errorMessage,
+            this, [this](const QString &objectPath, const QString &errorName) {
         if (objects().contains(objectPath) && errorName == UDISKS2_ERROR_DEVICE_BUSY) {
             m_message = errorName;
             if (!isCompleted() && deviceBusy()) {

--- a/src/udisks2job.cpp
+++ b/src/udisks2job.cpp
@@ -45,9 +45,8 @@ UDisks2::Job::Job(const QString &path, const QVariantMap &data, QObject *parent)
     , m_status(Added)
     , m_completed(false)
     , m_success(false)
-    , m_connection(QDBusConnection::systemBus())
 {
-    if (!m_path.isEmpty() && !m_connection.connect(
+    if (!m_path.isEmpty() && !QDBusConnection::systemBus().connect(
                 UDISKS2_SERVICE,
                 m_path,
                 UDISKS2_JOB_INTERFACE,
@@ -55,7 +54,7 @@ UDisks2::Job::Job(const QString &path, const QVariantMap &data, QObject *parent)
                 this,
                 SLOT(updateCompleted(bool, QString)))) {
         qCWarning(lcMemoryCardLog) << "Failed to connect to Job's at path" << qPrintable(m_path)
-                                   << "completed signal" << qPrintable(m_connection.lastError().message());
+                                   << "completed signal" << qPrintable(QDBusConnection::systemBus().lastError().message());
     }
 
     connect(Monitor::instance(), &Monitor::errorMessage,

--- a/src/udisks2job_p.h
+++ b/src/udisks2job_p.h
@@ -92,8 +92,6 @@ private:
     QString m_message;
     bool m_completed;
     bool m_success;
-
-    QDBusConnection m_connection;
 };
 }
 

--- a/src/udisks2job_p.h
+++ b/src/udisks2job_p.h
@@ -62,7 +62,7 @@ public:
     };
     Q_ENUM(Operation)
 
-    void complete(bool success);
+    void complete(bool success, const QString &message = QString());
     bool isCompleted() const;
     bool success() const;
     QString message() const;
@@ -80,9 +80,6 @@ public:
 
 signals:
     void completed(bool success);
-
-private slots:
-    void updateCompleted(bool success, const QString &message);
 
 private:
     QString m_path;

--- a/src/udisks2monitor.cpp
+++ b/src/udisks2monitor.cpp
@@ -562,7 +562,7 @@ void UDisks2::Monitor::startMountOperation(const QString &devicePath, const QStr
             QByteArray errorData = error.name().toLocal8Bit();
             const char *errorCStr = errorData.constData();
 
-            qCWarning(lcMemoryCardLog) << dbusMethod << "error:" << errorCStr;
+            qCWarning(lcMemoryCardLog) << "udisks2 error: " << dbusMethod << "error:" << errorCStr;
 
             for (uint i = 0; i < sizeof(dbus_error_entries) / sizeof(ErrorEntry); i++) {
                 if (strcmp(dbus_error_entries[i].dbusErrorName, errorCStr) == 0) {

--- a/src/udisks2monitor.cpp
+++ b/src/udisks2monitor.cpp
@@ -230,7 +230,8 @@ void UDisks2::Monitor::format(const QString &devicePath, const QString &filesyst
         // Lock unlocked block device before formatting.
         if (!partition->cryptoBackingDevicePath.isEmpty()) {
             lock(partition->cryptoBackingDevicePath);
-            m_operationQueue.enqueue(Operation(UDISKS2_BLOCK_FORMAT, partition->cryptoBackingDevicePath, objectPath, filesystemType, arguments));
+            m_operationQueue.enqueue(Operation(UDISKS2_BLOCK_FORMAT, partition->cryptoBackingDevicePath,
+                                               objectPath, filesystemType, arguments));
             return;
         } else if (partition->status == Partition::Mounted) {
             m_operationQueue.enqueue(Operation(UDISKS2_BLOCK_FORMAT, devicePath, objectPath, filesystemType, arguments));
@@ -254,12 +255,13 @@ void UDisks2::Monitor::interfacesAdded(const QDBusObjectPath &objectPath, const 
     } else if (path.startsWith(QStringLiteral("/org/freedesktop/UDisks2/jobs"))) {
         QVariantMap dict = interfaces.value(UDISKS2_JOB_INTERFACE);
         QString operation = dict.value(UDISKS2_JOB_KEY_OPERATION, QString()).toString();
-        if (operation == UDISKS2_JOB_OP_ENC_LOCK ||
-                operation == UDISKS2_JOB_OP_ENC_UNLOCK ||
-                operation == UDISKS2_JOB_OP_FS_MOUNT ||
-                operation == UDISKS2_JOB_OP_FS_UNMOUNT ||
-                operation == UDISKS2_JOB_OP_CLEANUP ||
-                operation == UDISKS2_JOB_OF_FS_FORMAT) {
+
+        if (operation == UDISKS2_JOB_OP_ENC_LOCK
+                || operation == UDISKS2_JOB_OP_ENC_UNLOCK
+                || operation == UDISKS2_JOB_OP_FS_MOUNT
+                || operation == UDISKS2_JOB_OP_FS_UNMOUNT
+                || operation == UDISKS2_JOB_OP_CLEANUP
+                || operation == UDISKS2_JOB_OF_FS_FORMAT) {
             UDisks2::Job *job = new UDisks2::Job(path, dict);
             updatePartitionStatus(job, true);
 
@@ -315,7 +317,8 @@ void UDisks2::Monitor::interfacesRemoved(const QDBusObjectPath &objectPath, cons
     }
 }
 
-void UDisks2::Monitor::setPartitionProperties(QExplicitlySharedDataPointer<PartitionPrivate> &partition, const UDisks2::Block *blockDevice)
+void UDisks2::Monitor::setPartitionProperties(QExplicitlySharedDataPointer<PartitionPrivate> &partition,
+                                              const UDisks2::Block *blockDevice)
 {
     QString label = blockDevice->idLabel();
     if (label.isEmpty()) {
@@ -373,7 +376,8 @@ void UDisks2::Monitor::updatePartitionProperties(const UDisks2::Block *blockDevi
     const QString cryptoBackingDevicePath = blockDevice->cryptoBackingDevicePath();
 
     for (auto partition : m_manager->m_partitions) {
-        if ((partition->devicePath == blockDevice->device()) || (hasCryptoBackingDevice && (partition->devicePath == cryptoBackingDevicePath))) {
+        if ((partition->devicePath == blockDevice->device())
+                || (hasCryptoBackingDevice && (partition->devicePath == cryptoBackingDevicePath))) {
             setPartitionProperties(partition, blockDevice);
             partition->valid = true;
             m_manager->refresh(partition.data());
@@ -412,14 +416,16 @@ void UDisks2::Monitor::updatePartitionStatus(const UDisks2::Job *job, bool succe
 
             if (success) {
                 if (job->status() == UDisks2::Job::Added) {
-                    partition->activeState = operation == UDisks2::Job::Mount ? QStringLiteral("activating") : QStringLiteral("deactivating");
+                    partition->activeState = operation == UDisks2::Job::Mount ? QStringLiteral("activating")
+                                                                              : QStringLiteral("deactivating");
                     partition->status = operation == UDisks2::Job::Mount ? Partition::Mounting : Partition::Unmounting;
                 } else {
                     // Completed busy unmount job shall stay in mounted state.
                     if (job->deviceBusy() && operation == UDisks2::Job::Unmount)
                         operation = UDisks2::Job::Mount;
 
-                    partition->activeState = operation == UDisks2::Job::Mount ? QStringLiteral("active") : QStringLiteral("inactive");
+                    partition->activeState = operation == UDisks2::Job::Mount ? QStringLiteral("active")
+                                                                              : QStringLiteral("inactive");
                     partition->status = operation == UDisks2::Job::Mount ? Partition::Mounted : Partition::Unmounted;
                 }
             } else {
@@ -460,7 +466,8 @@ void UDisks2::Monitor::updatePartitionStatus(const UDisks2::Job *job, bool succe
     }
 }
 
-void UDisks2::Monitor::startLuksOperation(const QString &devicePath, const QString &dbusMethod, const QString &dbusObjectPath, const QVariantList &arguments)
+void UDisks2::Monitor::startLuksOperation(const QString &devicePath, const QString &dbusMethod,
+                                          const QString &dbusObjectPath, const QVariantList &arguments)
 {
     Q_ASSERT(dbusMethod == UDISKS2_ENCRYPTED_LOCK || dbusMethod == UDISKS2_ENCRYPTED_UNLOCK);
 
@@ -522,7 +529,8 @@ void UDisks2::Monitor::startLuksOperation(const QString &devicePath, const QStri
     }
 }
 
-void UDisks2::Monitor::startMountOperation(const QString &devicePath, const QString &dbusMethod, const QString &dbusObjectPath, const QVariantList &arguments)
+void UDisks2::Monitor::startMountOperation(const QString &devicePath, const QString &dbusMethod,
+                                           const QString &dbusObjectPath, const QVariantList &arguments)
 {
     Q_ASSERT(dbusMethod == UDISKS2_FILESYSTEM_MOUNT || dbusMethod == UDISKS2_FILESYSTEM_UNMOUNT);
 
@@ -594,7 +602,8 @@ void UDisks2::Monitor::startMountOperation(const QString &devicePath, const QStr
     }
 }
 
-void UDisks2::Monitor::lookupPartitions(PartitionManagerPrivate::Partitions &affectedPartitions, const QStringList &objects)
+void UDisks2::Monitor::lookupPartitions(PartitionManagerPrivate::Partitions &affectedPartitions,
+                                        const QStringList &objects)
 {
     QStringList blockDevs = m_blockDevices->devicePaths(objects);
     for (const QString &dev : blockDevs) {
@@ -617,7 +626,8 @@ void UDisks2::Monitor::createPartition(const UDisks2::Block *block)
     m_manager->add(partition);
 }
 
-void UDisks2::Monitor::doFormat(const QString &devicePath, const QString &dbusObjectPath, const QString &filesystemType, const QVariantMap &arguments)
+void UDisks2::Monitor::doFormat(const QString &devicePath, const QString &dbusObjectPath,
+                                const QString &filesystemType, const QVariantMap &arguments)
 {
     QDBusInterface blockDeviceInterface(UDISKS2_SERVICE,
                                     dbusObjectPath,
@@ -704,7 +714,8 @@ void UDisks2::Monitor::connectSignals(UDisks2::Block *block)
 
         m_manager->blockSignals(true);
         QVariantMap data;
-        data.insert(UDISKS2_JOB_KEY_OPERATION, block->mountPath().isEmpty() ? UDISKS2_JOB_OP_FS_UNMOUNT : UDISKS2_JOB_OP_FS_MOUNT);
+        data.insert(UDISKS2_JOB_KEY_OPERATION, block->mountPath().isEmpty() ? UDISKS2_JOB_OP_FS_UNMOUNT
+                                                                            : UDISKS2_JOB_OP_FS_MOUNT);
         data.insert(UDISKS2_JOB_KEY_OBJECTS, QStringList() << block->path());
         qCDebug(lcMemoryCardLog) << "New partition status:" << data;
         UDisks2::Job tmpJob(QString(), data);
@@ -764,5 +775,4 @@ void UDisks2::Monitor::handleNewBlock(UDisks2::Block *block, bool forceCreatePar
     }
 
     connectSignals(block);
-
 }

--- a/src/udisks2monitor.cpp
+++ b/src/udisks2monitor.cpp
@@ -228,7 +228,7 @@ void UDisks2::Monitor::format(const QString &devicePath, const QString &filesyst
     }
 
     const QString objectPath = m_blockDevices->objectPath(devicePath);
-    PartitionManagerPrivate::Partitions affectedPartitions;
+    PartitionManagerPrivate::PartitionList affectedPartitions;
     lookupPartitions(affectedPartitions, QStringList() << objectPath);
 
     for (auto partition : affectedPartitions) {
@@ -319,7 +319,7 @@ void UDisks2::Monitor::interfacesRemoved(const QDBusObjectPath &objectPath, cons
         delete job;
     } else if (m_blockDevices->contains(path) && interfaces.contains(UDISKS2_BLOCK_INTERFACE)) {
         // Cleanup partitions first.
-        PartitionManagerPrivate::Partitions removedPartitions;
+        PartitionManagerPrivate::PartitionList removedPartitions;
         QStringList blockDevPaths = { path };
         lookupPartitions(removedPartitions, blockDevPaths);
         m_manager->remove(removedPartitions);
@@ -401,7 +401,7 @@ void UDisks2::Monitor::updatePartitionProperties(const UDisks2::Block *blockDevi
 void UDisks2::Monitor::updatePartitionStatus(const UDisks2::Job *job, bool success)
 {
     UDisks2::Job::Operation operation = job->operation();
-    PartitionManagerPrivate::Partitions affectedPartitions;
+    PartitionManagerPrivate::PartitionList affectedPartitions;
     lookupPartitions(affectedPartitions, job->objects());
     if (operation == UDisks2::Job::Lock || operation == UDisks2::Job::Unlock) {
         for (auto partition : affectedPartitions) {
@@ -615,7 +615,7 @@ void UDisks2::Monitor::startMountOperation(const QString &devicePath, const QStr
     }
 }
 
-void UDisks2::Monitor::lookupPartitions(PartitionManagerPrivate::Partitions &affectedPartitions,
+void UDisks2::Monitor::lookupPartitions(PartitionManagerPrivate::PartitionList &affectedPartitions,
                                         const QStringList &objects)
 {
     QStringList blockDevs = m_blockDevices->devicePaths(objects);
@@ -751,7 +751,7 @@ void UDisks2::Monitor::connectSignals(UDisks2::Block *block)
     }, Qt::UniqueConnection);
 
     connect(block, &UDisks2::Block::blockRemoved, this, [this](const QString &device) {
-        PartitionManagerPrivate::Partitions removedPartitions;
+        PartitionManagerPrivate::PartitionList removedPartitions;
         for (auto partition : m_manager->m_partitions) {
             if (partition->devicePath == device) {
                 removedPartitions << partition;

--- a/src/udisks2monitor_p.h
+++ b/src/udisks2monitor_p.h
@@ -115,7 +115,7 @@ private:
                             const QVariantList &arguments);
     void startMountOperation(const QString &devicePath, const QString &dbusMethod, const QString &dbusObjectPath,
                              const QVariantList &arguments);
-    void lookupPartitions(PartitionManagerPrivate::PartitionList &affectedPartitions, const QStringList &objects);
+    PartitionManagerPrivate::PartitionList lookupPartitions(const QStringList &objects);
 
     void createPartition(const Block *block);
     void getBlockDevices();

--- a/src/udisks2monitor_p.h
+++ b/src/udisks2monitor_p.h
@@ -55,7 +55,8 @@ class Job;
 
 struct Operation
 {
-    Operation(const QString &command, const QString &devicePath, const QString &dbusObjectPath = QString(), const QString &filesystemType = QString(), const QVariantMap &arguments  = QVariantMap())
+    Operation(const QString &command, const QString &devicePath, const QString &dbusObjectPath = QString(),
+              const QString &filesystemType = QString(), const QVariantMap &arguments  = QVariantMap())
         : command(command)
         , devicePath(devicePath)
         , dbusObjectPath(dbusObjectPath)
@@ -99,7 +100,8 @@ signals:
 private slots:
     void interfacesAdded(const QDBusObjectPath &objectPath, const UDisks2::InterfacePropertyMap &interfaces);
     void interfacesRemoved(const QDBusObjectPath &objectPath, const QStringList &interfaces);
-    void doFormat(const QString &devicePath, const QString &dbusObjectPath, const QString &filesystemType, const QVariantMap &arguments);
+    void doFormat(const QString &devicePath, const QString &dbusObjectPath, const QString &filesystemType,
+                  const QVariantMap &arguments);
     void handleNewBlock(UDisks2::Block *block, bool forceCreatePartition);
 
 private:
@@ -107,8 +109,10 @@ private:
     void updatePartitionProperties(const Block *blockDevice);
     void updatePartitionStatus(const Job *job, bool success);
 
-    void startLuksOperation(const QString &devicePath, const QString &dbusMethod, const QString &dbusObjectPath, const QVariantList &arguments);
-    void startMountOperation(const QString &devicePath, const QString &dbusMethod, const QString &dbusObjectPath, const QVariantList &arguments);
+    void startLuksOperation(const QString &devicePath, const QString &dbusMethod, const QString &dbusObjectPath,
+                            const QVariantList &arguments);
+    void startMountOperation(const QString &devicePath, const QString &dbusMethod, const QString &dbusObjectPath,
+                             const QVariantList &arguments);
     void lookupPartitions(PartitionManagerPrivate::Partitions &affectedPartitions, const QStringList &objects);
 
     void createPartition(const Block *block);

--- a/src/udisks2monitor_p.h
+++ b/src/udisks2monitor_p.h
@@ -34,6 +34,7 @@
 
 #include <QObject>
 #include <QDBusObjectPath>
+#include <QDBusContext>
 #include <QExplicitlySharedDataPointer>
 #include <QRegularExpression>
 #include <QQueue>
@@ -71,7 +72,7 @@ struct Operation
     QVariantMap arguments;
 };
 
-class Monitor : public QObject
+class Monitor : public QObject, protected QDBusContext
 {
     Q_OBJECT
 public:
@@ -103,6 +104,7 @@ private slots:
     void doFormat(const QString &devicePath, const QString &dbusObjectPath, const QString &filesystemType,
                   const QVariantMap &arguments);
     void handleNewBlock(UDisks2::Block *block, bool forceCreatePartition);
+    void jobCompleted(bool success, const QString &msg);
 
 private:
     void setPartitionProperties(QExplicitlySharedDataPointer<PartitionPrivate> &partition, const Block *blockDevice);

--- a/src/udisks2monitor_p.h
+++ b/src/udisks2monitor_p.h
@@ -115,7 +115,7 @@ private:
                             const QVariantList &arguments);
     void startMountOperation(const QString &devicePath, const QString &dbusMethod, const QString &dbusObjectPath,
                              const QVariantList &arguments);
-    void lookupPartitions(PartitionManagerPrivate::Partitions &affectedPartitions, const QStringList &objects);
+    void lookupPartitions(PartitionManagerPrivate::PartitionList &affectedPartitions, const QStringList &objects);
 
     void createPartition(const Block *block);
     void getBlockDevices();


### PR DESCRIPTION
Was developed with Udisks2 update which suffered from D-Bus property change signal handler shortcoming, maybe triggering the problem by including a bit different content in the change signal. 

But there shouldn't be much version update specific things here and this should be ok to merge on its own. There's mostly just the 'mkfs-args' property if added by api client (i.e. not without changes elsewhere) and even if included the old udisks2 should just ignore it. Tested that the old udisks2 version also suffers from badly handled job finish tracking.

See individual commits for more details.
