### PR TITLE
Async disk usage refresh

### DIFF
--- a/src/partition.cpp
+++ b/src/partition.cpp
@@ -143,17 +143,17 @@ bool Partition::isSupportedFileSystemType() const
 
 qint64 Partition::bytesAvailable() const
 {
-    return d ? d->bytesAvailable : 0;
+    return d ? d->bytesAvailable : -1;
 }
 
 qint64 Partition::bytesTotal() const
 {
-    return d ? d->bytesTotal : 0;
+    return d ? d->bytesTotal : -1;
 }
 
 qint64 Partition::bytesFree() const
 {
-    return d ? d->bytesFree : 0;
+    return d ? d->bytesFree : -1;
 }
 
 void Partition::refresh()

--- a/src/partition_p.h
+++ b/src/partition_p.h
@@ -43,9 +43,9 @@ class PartitionPrivate : public QSharedData
 public:
     PartitionPrivate(PartitionManagerPrivate *manager)
         : manager(manager)
-        , bytesAvailable(0)
-        , bytesTotal(0)
-        , bytesFree(0)
+        , bytesAvailable(-1)
+        , bytesTotal(-1)
+        , bytesFree(-1)
         , storageType(Partition::Invalid)
         , status(Partition::Unmounted)
         , readOnly(true)

--- a/src/partitionmanager.cpp
+++ b/src/partitionmanager.cpp
@@ -119,6 +119,11 @@ PartitionManagerPrivate::PartitionManagerPrivate()
     if (root->status == Partition::Mounted) {
         m_root = Partition(QExplicitlySharedDataPointer<PartitionPrivate>(root));
     }
+
+    m_refreshTimer.setSingleShot(true);
+    m_refreshTimer.setInterval(10);
+    connect(&m_refreshTimer, SIGNAL(timeout()),
+            this, SLOT(refresh()));
 }
 
 PartitionManagerPrivate::~PartitionManagerPrivate()
@@ -188,6 +193,11 @@ void PartitionManagerPrivate::remove(const PartitionList &partitions)
 
         emit partitionRemoved(Partition(removedPartition));
     }
+}
+
+void PartitionManagerPrivate::scheduleRefresh()
+{
+    m_refreshTimer.start();
 }
 
 void PartitionManagerPrivate::refresh()
@@ -407,5 +417,5 @@ QVector<Partition> PartitionManager::partitions(Partition::StorageTypes types) c
 
 void PartitionManager::refresh()
 {
-    d->refresh();
+    d->scheduleRefresh();
 }

--- a/src/partitionmanager_p.h
+++ b/src/partitionmanager_p.h
@@ -38,6 +38,7 @@
 #include <QMap>
 #include <QVector>
 #include <QScopedPointer>
+#include <QTimer>
 
 namespace UDisks2 {
 class Monitor;
@@ -61,7 +62,7 @@ public:
     void add(QExplicitlySharedDataPointer<PartitionPrivate> partition);
     void remove(const PartitionList &partitions);
 
-    void refresh();
+    void scheduleRefresh();
     void refresh(PartitionPrivate *partition);
     void refresh(const PartitionList &partitions, PartitionList &changedPartitions);
 
@@ -75,6 +76,9 @@ public:
 
     QStringList supportedFileSystems() const;
     bool externalStoragesPopulated() const;
+
+public slots:
+    void refresh();
 
 signals:
     void partitionChanged(const Partition &partition);
@@ -97,13 +101,13 @@ private:
 
     PartitionList m_partitions;
     Partition m_root;
+    QTimer m_refreshTimer;
 
     QScopedPointer<UDisks2::Monitor> m_udisksMonitor;
 
     // Allow direct access to the Partitions.
     friend class UDisks2::Monitor;
 };
-
 
 #endif
 

--- a/src/partitionmanager_p.h
+++ b/src/partitionmanager_p.h
@@ -44,7 +44,6 @@ namespace UDisks2 {
 class Monitor;
 }
 
-
 class PartitionManagerPrivate : public QObject, public QSharedData
 {
     Q_OBJECT
@@ -64,7 +63,7 @@ public:
 
     void scheduleRefresh();
     void refresh(PartitionPrivate *partition);
-    void refresh(const PartitionList &partitions, PartitionList &changedPartitions);
+    void refresh(const PartitionList &partitions);
 
     void lock(const QString &devicePath);
     void unlock(const Partition &partition, const QString &passphrase);
@@ -76,6 +75,8 @@ public:
 
     QStringList supportedFileSystems() const;
     bool externalStoragesPopulated() const;
+
+    bool event(QEvent *event) override;
 
 public slots:
     void refresh();
@@ -110,4 +111,3 @@ private:
 };
 
 #endif
-

--- a/src/partitionmodel.cpp
+++ b/src/partitionmodel.cpp
@@ -115,7 +115,7 @@ bool PartitionModel::externalStoragesPopulated() const
 
 void PartitionModel::refresh()
 {
-    m_manager->refresh();
+    m_manager->scheduleRefresh();
 }
 
 void PartitionModel::refresh(int index)

--- a/src/udisks2monitor.cpp
+++ b/src/udisks2monitor.cpp
@@ -456,9 +456,9 @@ void UDisks2::Monitor::updatePartitionStatus(const UDisks2::Job *job, bool succe
                 if (job->status() == UDisks2::Job::Added) {
                     partition->activeState = QStringLiteral("inactive");
                     partition->status = Partition::Formatting;
-                    partition->bytesAvailable = 0;
-                    partition->bytesTotal = 0;
-                    partition->bytesFree = 0;
+                    partition->bytesAvailable = -1;
+                    partition->bytesTotal = -1;
+                    partition->bytesFree = -1;
                     partition->filesystemType.clear();
                     partition->canMount = false;
                     partition->valid = false;


### PR DESCRIPTION
Two commits. First avoid some unnecessary refresh() loops when updating multiple models at the same time. Second one moves the statvfs64() to separate thread. Especially with FAT based filesystems it seems it can take multiple seconds after mounting.