### PR TITLE
[nemo-systemsettings] Skip redundant properties on certificate key details. JB#63260

### DIFF
--- a/src/certificatemodel.cpp
+++ b/src/certificatemodel.cpp
@@ -638,6 +638,10 @@ Certificate::Certificate(const X509Certificate &cert)
     QVariantMap publicKey;
     const QList<QPair<QString, QString>> &keyDetails(cert.publicKeyList());
     for (auto it = keyDetails.cbegin(), end = keyDetails.cend(); it != end; ++it) {
+        // publicKeyList() adds "Bits" and "Algorithm" fields which include the same thing more nicely
+        if (it->first == QLatin1String("Public-Key") || it->first == QLatin1String("RSA Public-Key")) {
+            continue;
+        }
         publicKey.insert(it->first, QVariant(it->second));
     }
     m_details.insert(QStringLiteral("SubjectPublicKeyInfo"), QVariant(publicKey));


### PR DESCRIPTION
The publicKeyList() adds custom "Algorithm" and "Bits" fields but was then also including "Public-Key: (384 bit)" or "RSA Public-Key: 4096 bit)" type of fields.

These are redundant and the Sailfish UI didn't have translation support for the RSA variant. Let's just skip these.