### PR TITLE
Location settings: add hybris and some fixing

### DIFF
--- a/src/locationsettings.cpp
+++ b/src/locationsettings.cpp
@@ -82,8 +82,8 @@ namespace {
 IniFile::IniFile(const QString &fileName, const QString &compatibilityFileName)
     : m_fileName(fileName)
     , m_compatibilityFileName(compatibilityFileName)
-    , m_keyFile(Q_NULLPTR)
-    , m_error(Q_NULLPTR)
+    , m_keyFile(nullptr)
+    , m_error(nullptr)
     , m_modified(false)
     , m_valid(false)
 {
@@ -101,7 +101,7 @@ IniFile::IniFile(const QString &fileName, const QString &compatibilityFileName)
             qWarning() << "Unable to load key file:" << m_fileName << ":"
                        << m_error->code << QString::fromUtf8(m_error->message);
             g_error_free(m_error);
-            m_error = Q_NULLPTR;
+            m_error = nullptr;
         } else {
             m_valid = true;
         }
@@ -118,7 +118,7 @@ IniFile::~IniFile()
             qWarning() << "Unable to save changes to key file:" << m_fileName << ":"
                        << m_error->code << QString::fromUtf8(m_error->message);
             g_error_free(m_error);
-            m_error = Q_NULLPTR;
+            m_error = nullptr;
         }
 
         if (!m_compatibilityFileName.isEmpty()) {
@@ -127,9 +127,9 @@ IniFile::~IniFile()
                                     &m_error);
             if (m_error) {
                 qWarning() << "Unable to save changes to compatibility key file:" << m_compatibilityFileName << ":"
-                       << m_error->code << QString::fromUtf8(m_error->message);
+                           << m_error->code << QString::fromUtf8(m_error->message);
                 g_error_free(m_error);
-                m_error = Q_NULLPTR;
+                m_error = nullptr;
             }
         }
     }
@@ -159,7 +159,7 @@ bool IniFile::readBool(const QString &section, const QString &key, bool *value, 
                        << m_error->code << QString::fromUtf8(m_error->message);
         }
         g_error_free(m_error);
-        m_error = Q_NULLPTR;
+        m_error = nullptr;
         *value = defaultValue;
         return false;
     }
@@ -193,9 +193,9 @@ LocationSettingsPrivate::LocationSettingsPrivate(LocationSettings::Mode mode, Lo
     , m_locationMode(LocationSettings::CustomMode)
     , m_settingMultipleSettings(false)
     , m_allowedDataSources(static_cast<LocationSettings::DataSources>(std::numeric_limits<quint32>::max()))
-    , m_gpsTech(Q_NULLPTR)
+    , m_gpsTech(nullptr)
     , m_gpsTechInterface(mode == LocationSettings::AsynchronousMode
-                         ? Q_NULLPTR
+                         ? nullptr
                          : new NemoDBus::Interface(
                                 this, QDBusConnection::systemBus(),
                                 "net.connman",
@@ -234,11 +234,11 @@ LocationSettingsPrivate::~LocationSettingsPrivate()
 {
     if (m_gpsTech) {
         disconnect(m_gpsTech, 0, q, 0);
-        m_gpsTech = 0;
+        m_gpsTech = nullptr;
     }
 
     delete m_gpsTechInterface;
-    m_gpsTechInterface = 0;
+    m_gpsTechInterface = nullptr;
 }
 
 void LocationSettingsPrivate::loadProviders()
@@ -501,7 +501,7 @@ bool LocationSettings::gpsFlightMode() const
         }
         return false;
     }
-    return d->m_gpsTech == Q_NULLPTR ? false : !(d->m_gpsTech->powered());
+    return d->m_gpsTech == nullptr ? false : !(d->m_gpsTech->powered());
 }
 
 void LocationSettings::setGpsFlightMode(bool flightMode)

--- a/src/locationsettings.cpp
+++ b/src/locationsettings.cpp
@@ -244,15 +244,25 @@ LocationSettingsPrivate::~LocationSettingsPrivate()
 
 void LocationSettingsPrivate::loadProviders()
 {
+    // Note: on a sandbox the detected providers list may not be right
+    // TODO: could be better if we provided some config file with each provider
+    // rather than hard-coding here the details and detecting availability.
+
     // for now just hard-coding the known potential providers.
     // can be replaced with config type of thing if there's need to support more and more providers.
     if (QFile::exists(QStringLiteral("/usr/libexec/geoclue-here"))) {
+        m_detectedProviders.append(HereName);
+    }
+    {
         LocationProvider provider;
         provider.hasAgreement = true;
         m_providers[HereName] = provider;
     }
 
     if (QFile::exists(QStringLiteral("/usr/libexec/geoclue-mlsdb"))) {
+        m_detectedProviders.append(MlsName);
+    }
+    {
         LocationProvider provider;
         provider.hasAgreement = true;
         provider.offlineCapable = true;
@@ -260,12 +270,18 @@ void LocationSettingsPrivate::loadProviders()
     }
 
     if (QFile::exists(QStringLiteral("/usr/libexec/geoclue-yandex"))) {
+        m_detectedProviders.append(YandexName);
+    }
+    {
         LocationProvider provider;
         provider.hasAgreement = true; // supposedly
         m_providers[YandexName] = provider;
     }
 
     if (QFile::exists(QStringLiteral("/usr/libexec/geoclue-hybris"))) {
+        m_detectedProviders.append(HybrisName);
+    }
+    {
         LocationProvider provider;
         provider.offlineCapable = true; // used to separate the basic and extra network requests modes
         provider.hasAgreement = false;
@@ -308,8 +324,11 @@ bool LocationSettingsPrivate::updateProvider(const QString &name, const Location
             }
         } else if (provider.hasAgreement) {
             if (!provider.agreementAccepted && !m_pendingAgreements.contains(name)) {
-                m_pendingAgreements.append(name);
-                emit q->pendingAgreementsChanged();
+                // include only installed providers as possible pending agreement
+                if (m_detectedProviders.contains(name)) {
+                    m_pendingAgreements.append(name);
+                    emit q->pendingAgreementsChanged();
+                }
             } else if (provider.agreementAccepted && m_pendingAgreements.contains(name)) {
                 m_pendingAgreements.removeOne(name);
                 emit q->pendingAgreementsChanged();
@@ -544,7 +563,7 @@ bool LocationSettings::gpsAvailable() const
 QStringList LocationSettings::locationProviders() const
 {
     Q_D(const LocationSettings);
-    return d->m_providers.keys();
+    return d->m_detectedProviders;
 }
 
 LocationProvider LocationSettings::providerInfo(const QString &name) const
@@ -573,7 +592,7 @@ bool LocationSettings::mlsEnabled() const
 
 void LocationSettings::setMlsEnabled(bool enabled)
 {
-    if (mlsAvailable() && enabled != mlsEnabled()) {
+    if (enabled != mlsEnabled()) {
         LocationProvider provider = providerInfo(MlsName);
         provider.offlineEnabled = enabled;
         updateLocationProvider(MlsName, provider);
@@ -595,7 +614,7 @@ void LocationSettings::setMlsOnlineState(LocationSettings::OnlineAGpsState state
 bool LocationSettings::mlsAvailable() const
 {
     Q_D(const LocationSettings);
-    return d->m_providers.contains(MlsName);
+    return d->m_detectedProviders.contains(MlsName);
 }
 
 /*Yandex  services*/
@@ -614,7 +633,7 @@ void LocationSettings::setYandexOnlineState(LocationSettings::OnlineAGpsState st
 bool LocationSettings::yandexAvailable() const
 {
     Q_D(const LocationSettings);
-    return d->m_providers.contains(YandexName);
+    return d->m_detectedProviders.contains(YandexName);
 }
 
 /*HERE*/
@@ -633,14 +652,14 @@ void LocationSettings::setHereState(LocationSettings::OnlineAGpsState state)
 bool LocationSettings::hereAvailable() const
 {
     Q_D(const LocationSettings);
-    return d->m_providers.contains(HereName);
+    return d->m_detectedProviders.contains(HereName);
 }
 
 // Hybris
 bool LocationSettings::hybrisAvailable() const
 {
     Q_D(const LocationSettings);
-    return d->m_providers.contains(HybrisName);
+    return d->m_detectedProviders.contains(HybrisName);
 }
 
 bool LocationSettings::hybrisEnabled() const
@@ -651,7 +670,7 @@ bool LocationSettings::hybrisEnabled() const
 
 void LocationSettings::setHybrisEnabled(bool enabled)
 {
-    if (hybrisAvailable() && enabled != hybrisEnabled()) {
+    if (enabled != hybrisEnabled()) {
         LocationProvider provider = providerInfo(HybrisName);
         provider.offlineEnabled = enabled;
         updateLocationProvider(HybrisName, provider);
@@ -764,7 +783,7 @@ void LocationSettingsPrivate::readSettings()
             updateProvider(name, provider);
         }
 
-        if (m_providers.contains(HybrisName)) {
+        {
             // falling back to mls state if no explicit config
             LocationProvider provider;
             ini.readBool(LocationSettingsSection, ProviderOfflineEnabledPattern.arg(HybrisName),

--- a/src/locationsettings.cpp
+++ b/src/locationsettings.cpp
@@ -47,10 +47,6 @@
 #include <limits>
 
 namespace {
-    const QString LocationSettingsDeprecatedCellIdPositioningEnabledKey = QStringLiteral("cell_id_positioning_enabled");
-    const QString LocationSettingsDeprecatedHereEnabledKey = QStringLiteral("here_agreement_accepted");
-    const QString LocationSettingsDeprecatedHereAgreementAcceptedKey = QStringLiteral("agreement_accepted");
-
     const QString PoweredPropertyName = QStringLiteral("Powered");
     const QString LocationSettingsDir = QStringLiteral("/var/lib/location/");
     const QString LocationSettingsFile = QStringLiteral("/var/lib/location/location.conf");
@@ -703,14 +699,6 @@ void LocationSettingsPrivate::readSettings()
             return;
         }
 
-        // read the deprecated keys first for backward compatibility
-        bool oldMlsEnabled = false;
-        bool oldHereEnabled = false;
-        bool oldHereAgreementAccepted = false;
-        ini.readBool(LocationSettingsSection, LocationSettingsDeprecatedCellIdPositioningEnabledKey, &oldMlsEnabled);
-        ini.readBool(LocationSettingsSection, LocationSettingsDeprecatedHereEnabledKey, &oldHereEnabled);
-        ini.readBool(LocationSettingsSection, LocationSettingsDeprecatedHereAgreementAcceptedKey, &oldHereAgreementAccepted);
-
         // then read the current keys
         ini.readBool(LocationSettingsSection, LocationSettingsEnabledKey, &locationEnabled);
         ini.readBool(LocationSettingsSection, LocationSettingsCustomModeKey, &customMode);
@@ -718,12 +706,6 @@ void LocationSettingsPrivate::readSettings()
 
         for (const QString &name : m_providers.keys()) {
             LocationProvider provider;
-            if (name == MlsName) {
-                provider.offlineEnabled = oldMlsEnabled;
-            } else if (name == HereName) {
-                provider.onlineEnabled = oldHereEnabled;
-                provider.agreementAccepted = oldHereAgreementAccepted;
-            }
             ini.readBool(LocationSettingsSection, ProviderOfflineEnabledPattern.arg(name), &provider.offlineEnabled);
             ini.readBool(LocationSettingsSection, ProviderOnlineEnabledPattern.arg(name), &provider.onlineEnabled);
             ini.readBool(LocationSettingsSection, ProviderAgreementAcceptedPattern.arg(name), &provider.agreementAccepted);

--- a/src/locationsettings.cpp
+++ b/src/locationsettings.cpp
@@ -77,6 +77,7 @@ namespace {
     const QString YandexName = QStringLiteral("yandex");
     const QString HereName = QStringLiteral("here");
     const QString MlsName = QStringLiteral("mls");
+    const QString HybrisName = QStringLiteral("hybris");
 }
 
 IniFile::IniFile(const QString &fileName, const QString &compatibilityFileName)
@@ -263,6 +264,13 @@ void LocationSettingsPrivate::loadProviders()
         provider.hasAgreement = true; // supposedly
         m_providers[YandexName] = provider;
     }
+
+    if (QFile::exists(QStringLiteral("/usr/libexec/geoclue-hybris"))) {
+        LocationProvider provider;
+        provider.offlineCapable = true; // used to separate the basic and extra network requests modes
+        provider.hasAgreement = false;
+        m_providers[HybrisName] = provider;
+    }
 }
 
 bool LocationSettingsPrivate::updateProvider(const QString &name, const LocationProvider &state)
@@ -309,9 +317,14 @@ bool LocationSettingsPrivate::updateProvider(const QString &name, const Location
         }
     }
 
-    if (offlineEnabledChanged && name == MlsName) {
-        emit q->mlsEnabledChanged();
+    if (offlineEnabledChanged) {
+        if (name == MlsName) {
+            emit q->mlsEnabledChanged();
+        } else if (name == HybrisName) {
+            emit q->hybrisEnabledChanged();
+        }
     }
+
     if (agreementChanged || onlineEnabledChanged) {
         if (name == HereName) {
             emit q->hereStateChanged();
@@ -319,6 +332,8 @@ bool LocationSettingsPrivate::updateProvider(const QString &name, const Location
             emit q->mlsOnlineStateChanged();
         } else if (name == YandexName) {
             emit q->yandexOnlineStateChanged();
+        } else if (name == HybrisName) {
+            emit q->hybrisOnlineStateChanged();
         }
     }
 
@@ -621,6 +636,40 @@ bool LocationSettings::hereAvailable() const
     return d->m_providers.contains(HereName);
 }
 
+// Hybris
+bool LocationSettings::hybrisAvailable() const
+{
+    Q_D(const LocationSettings);
+    return d->m_providers.contains(HybrisName);
+}
+
+bool LocationSettings::hybrisEnabled() const
+{
+    Q_D(const LocationSettings);
+    return d->m_providers.value(HybrisName).offlineEnabled;
+}
+
+void LocationSettings::setHybrisEnabled(bool enabled)
+{
+    if (hybrisAvailable() && enabled != hybrisEnabled()) {
+        LocationProvider provider = providerInfo(HybrisName);
+        provider.offlineEnabled = enabled;
+        updateLocationProvider(HybrisName, provider);
+    }
+}
+
+LocationSettings::OnlineAGpsState LocationSettings::hybrisOnlineState() const
+{
+    Q_D(const LocationSettings);
+    return d->onlineState(HybrisName);
+}
+
+void LocationSettings::setHybrisOnlineState(LocationSettings::OnlineAGpsState state)
+{
+    Q_D(LocationSettings);
+    d->updateOnlineAgpsState(HybrisName, state);
+}
+
 LocationSettings::LocationMode LocationSettings::locationMode() const
 {
     Q_D(const LocationSettings);
@@ -705,11 +754,26 @@ void LocationSettingsPrivate::readSettings()
         ini.readBool(LocationSettingsSection, LocationSettingsGpsEnabledKey, &gpsEnabled);
 
         for (const QString &name : m_providers.keys()) {
+            if (name == HybrisName) {
+                continue; // read this separately last to get proper defaults
+            }
             LocationProvider provider;
             ini.readBool(LocationSettingsSection, ProviderOfflineEnabledPattern.arg(name), &provider.offlineEnabled);
             ini.readBool(LocationSettingsSection, ProviderOnlineEnabledPattern.arg(name), &provider.onlineEnabled);
             ini.readBool(LocationSettingsSection, ProviderAgreementAcceptedPattern.arg(name), &provider.agreementAccepted);
             updateProvider(name, provider);
+        }
+
+        if (m_providers.contains(HybrisName)) {
+            // falling back to mls state if no explicit config
+            LocationProvider provider;
+            ini.readBool(LocationSettingsSection, ProviderOfflineEnabledPattern.arg(HybrisName),
+                         &provider.offlineEnabled,
+                         m_providers.value(MlsName).offlineEnabled);
+            ini.readBool(LocationSettingsSection, ProviderOnlineEnabledPattern.arg(HybrisName),
+                         &provider.onlineEnabled,
+                         m_providers.value(MlsName).onlineEnabled);
+            updateProvider(HybrisName, provider);
         }
 
         // read the MDM allowed allowed data source keys

--- a/src/locationsettings.cpp
+++ b/src/locationsettings.cpp
@@ -353,7 +353,7 @@ LocationSettings::OnlineAGpsState LocationSettingsPrivate::onlineState(const QSt
         if (!provider.onlineCapable) {
             resultValid = false;
             result = LocationSettings::OnlineAGpsAgreementNotAccepted;
-        } else if (!provider.agreementAccepted) {
+        } else if (provider.hasAgreement && !provider.agreementAccepted) {
             result = LocationSettings::OnlineAGpsAgreementNotAccepted;
         } else {
             result = provider.onlineEnabled ? LocationSettings::OnlineAGpsEnabled

--- a/src/locationsettings.h
+++ b/src/locationsettings.h
@@ -177,6 +177,7 @@ signals:
 
 private:
     LocationSettingsPrivate *d_ptr;
+
     Q_DISABLE_COPY(LocationSettings)
     Q_DECLARE_PRIVATE(LocationSettings)
 };

--- a/src/locationsettings.h
+++ b/src/locationsettings.h
@@ -41,7 +41,8 @@
 
 #define LOCATION_SETTINGS_LAST_DATA_SOURCE_BIT 31
 
-struct LocationProvider {
+struct LocationProvider
+{
     bool hasAgreement = false;
     bool agreementAccepted = false;
     bool onlineCapable = true;
@@ -56,6 +57,7 @@ struct LocationProvider {
 // Or setting location mode to custom, and modifying specific details.
 
 class LocationSettingsPrivate;
+
 class SYSTEMSETTINGS_EXPORT LocationSettings : public QObject
 {
     Q_OBJECT
@@ -77,6 +79,9 @@ class SYSTEMSETTINGS_EXPORT LocationSettings : public QObject
     Q_PROPERTY(OnlineAGpsState mlsOnlineState READ mlsOnlineState WRITE setMlsOnlineState NOTIFY mlsOnlineStateChanged)
     Q_PROPERTY(bool yandexAvailable READ yandexAvailable CONSTANT)
     Q_PROPERTY(OnlineAGpsState yandexOnlineState READ yandexOnlineState WRITE setYandexOnlineState NOTIFY yandexOnlineStateChanged)
+    Q_PROPERTY(bool hybrisAvailable READ hybrisAvailable CONSTANT)
+    Q_PROPERTY(bool hybrisEnabled READ hybrisEnabled WRITE setHybrisEnabled NOTIFY hybrisEnabledChanged)
+    Q_PROPERTY(OnlineAGpsState hybrisOnlineState READ hybrisOnlineState WRITE setHybrisOnlineState NOTIFY hybrisOnlineStateChanged)
 
     Q_ENUMS(OnlineAGpsState)
     Q_ENUMS(LocationMode)
@@ -156,6 +161,12 @@ public:
     void setYandexOnlineState(OnlineAGpsState state);
     bool yandexAvailable() const;
 
+    bool hybrisAvailable() const;
+    bool hybrisEnabled() const;
+    void setHybrisEnabled(bool enabled);
+    OnlineAGpsState hybrisOnlineState() const;
+    void setHybrisOnlineState(OnlineAGpsState state);
+
     LocationMode locationMode() const;
     void setLocationMode(LocationMode locationMode);
     QStringList pendingAgreements() const;
@@ -174,6 +185,8 @@ signals:
     void mlsEnabledChanged();
     void mlsOnlineStateChanged();
     void yandexOnlineStateChanged();
+    void hybrisEnabledChanged();
+    void hybrisOnlineStateChanged();
 
 private:
     LocationSettingsPrivate *d_ptr;

--- a/src/locationsettings_p.h
+++ b/src/locationsettings_p.h
@@ -73,6 +73,7 @@ public:
     bool m_locationEnabled;
     bool m_gpsEnabled;
     QHash<QString, LocationProvider> m_providers;
+    QStringList m_detectedProviders;
     LocationSettings::LocationMode m_locationMode;
     bool m_settingMultipleSettings;
     QStringList m_pendingAgreements;

--- a/src/plugin/plugins.qmltypes
+++ b/src/plugin/plugins.qmltypes
@@ -413,6 +413,9 @@ Module {
         Property { name: "mlsOnlineState"; type: "OnlineAGpsState" }
         Property { name: "yandexAvailable"; type: "bool"; isReadonly: true }
         Property { name: "yandexOnlineState"; type: "OnlineAGpsState" }
+        Property { name: "hybrisAvailable"; type: "bool"; isReadonly: true }
+        Property { name: "hybrisEnabled"; type: "bool" }
+        Property { name: "hybrisOnlineState"; type: "OnlineAGpsState" }
     }
     Component {
         name: "NfcSettings"


### PR DESCRIPTION
Adding here explicit config for geoclue-providers-hybris so it doesn't need to guess from mls & here config what it should be doing.

Noticed that the config system seemed a bit problematic with sandboxing: this tries autodetect installed geoclue providers and earlier ignored all the configuration for the ones not detected. Sandbox doesn't necessarily allow visibility to the providers.